### PR TITLE
weekの体調データをできるように対応

### DIFF
--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2E0ACDF32B93E42200318BF2 /* TodaysPhysicalConditionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF22B93E42200318BF2 /* TodaysPhysicalConditionListView.swift */; };
-		2E0ACDF52B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF42B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift */; };
+		2E0ACDF32B93E42200318BF2 /* DailyPhysicalConditionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF22B93E42200318BF2 /* DailyPhysicalConditionList.swift */; };
+		2E0ACDF52B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF42B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift */; };
 		2E0ACDF82B947CD800318BF2 /* ActivityEditDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF72B947CD800318BF2 /* ActivityEditDestination.swift */; };
 		2E0ACDFA2B947DB100318BF2 /* PhysicalConditionEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF92B947DB100318BF2 /* PhysicalConditionEditForm.swift */; };
 		2E0ACDFC2B9690F300318BF2 /* PhysicalConditionCreateForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDFB2B9690F300318BF2 /* PhysicalConditionCreateForm.swift */; };
@@ -30,8 +30,8 @@
 		2E0DA4252B8D5DC4004E0185 /* GraphDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4242B8D5DC4004E0185 /* GraphDefinition.swift */; };
 		2E0DA4282B8E10EB004E0185 /* ChartXAxisModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4272B8E10EB004E0185 /* ChartXAxisModifier.swift */; };
 		2E0DA42A2B8E113D004E0185 /* PhysicalConditionChartYModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4292B8E113D004E0185 /* PhysicalConditionChartYModifier.swift */; };
-		2E631C6E2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C6D2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift */; };
-		2E631C702B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */; };
+		2E631C6E2B896F0D00B35AAC /* PhysicalConditionGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C6D2B896F0D00B35AAC /* PhysicalConditionGraph.swift */; };
+		2E631C702B8972E800B35AAC /* PhysicalConditionGraphModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C6F2B8972E800B35AAC /* PhysicalConditionGraphModel.swift */; };
 		2E631C732B8A180E00B35AAC /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C722B8A180E00B35AAC /* Date+Extensions.swift */; };
 		2E631C742B8A180E00B35AAC /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C722B8A180E00B35AAC /* Date+Extensions.swift */; };
 		2E6983652B9C728D0076EF4F /* WeekCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6983642B9C728D0076EF4F /* WeekCondition.swift */; };
@@ -40,6 +40,7 @@
 		2E69836B2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */; };
 		2E69836D2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */; };
 		2E6983702B9DACC50076EF4F /* DateWithPhysicalCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836F2B9DACC50076EF4F /* DateWithPhysicalCondition.swift */; };
+		2E6983722B9E767D0076EF4F /* SelectedDatePhysicalConditionGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6983712B9E767D0076EF4F /* SelectedDatePhysicalConditionGraph.swift */; };
 		2E6E640E2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */; };
 		2E6E640F2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */; };
 		2E6E64112B7EDEE900A11DB9 /* StyleConst.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E64102B7EDEE900A11DB9 /* StyleConst.swift */; };
@@ -109,8 +110,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		2E0ACDF22B93E42200318BF2 /* TodaysPhysicalConditionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaysPhysicalConditionListView.swift; sourceTree = "<group>"; };
-		2E0ACDF42B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaysPhysicalConditionListViewModel.swift; sourceTree = "<group>"; };
+		2E0ACDF22B93E42200318BF2 /* DailyPhysicalConditionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPhysicalConditionList.swift; sourceTree = "<group>"; };
+		2E0ACDF42B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPhysicalConditionListViewModel.swift; sourceTree = "<group>"; };
 		2E0ACDF72B947CD800318BF2 /* ActivityEditDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEditDestination.swift; sourceTree = "<group>"; };
 		2E0ACDF92B947DB100318BF2 /* PhysicalConditionEditForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionEditForm.swift; sourceTree = "<group>"; };
 		2E0ACDFB2B9690F300318BF2 /* PhysicalConditionCreateForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionCreateForm.swift; sourceTree = "<group>"; };
@@ -132,8 +133,8 @@
 		2E0DA4242B8D5DC4004E0185 /* GraphDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphDefinition.swift; sourceTree = "<group>"; };
 		2E0DA4272B8E10EB004E0185 /* ChartXAxisModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartXAxisModifier.swift; sourceTree = "<group>"; };
 		2E0DA4292B8E113D004E0185 /* PhysicalConditionChartYModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionChartYModifier.swift; sourceTree = "<group>"; };
-		2E631C6D2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayPhysicalConditionGraph.swift; sourceTree = "<group>"; };
-		2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayPhysicalConditionGraphViewModel.swift; sourceTree = "<group>"; };
+		2E631C6D2B896F0D00B35AAC /* PhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionGraph.swift; sourceTree = "<group>"; };
+		2E631C6F2B8972E800B35AAC /* PhysicalConditionGraphModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionGraphModel.swift; sourceTree = "<group>"; };
 		2E631C722B8A180E00B35AAC /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		2E6983642B9C728D0076EF4F /* WeekCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekCondition.swift; sourceTree = "<group>"; };
 		2E6983662B9C73720076EF4F /* WeekPhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionGraph.swift; sourceTree = "<group>"; };
@@ -141,6 +142,7 @@
 		2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionListView.swift; sourceTree = "<group>"; };
 		2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionListViewModel.swift; sourceTree = "<group>"; };
 		2E69836F2B9DACC50076EF4F /* DateWithPhysicalCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateWithPhysicalCondition.swift; sourceTree = "<group>"; };
+		2E6983712B9E767D0076EF4F /* SelectedDatePhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedDatePhysicalConditionGraph.swift; sourceTree = "<group>"; };
 		2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionRating.swift; sourceTree = "<group>"; };
 		2E6E64102B7EDEE900A11DB9 /* StyleConst.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleConst.swift; sourceTree = "<group>"; };
 		2E6E64142B80460400A11DB9 /* PhysicalConditionEntryFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionEntryFormViewModel.swift; sourceTree = "<group>"; };
@@ -318,7 +320,6 @@
 		2E631C6C2B896EE800B35AAC /* Graphs */ = {
 			isa = PBXGroup;
 			children = (
-				2E631C6D2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift */,
 				2E6983662B9C73720076EF4F /* WeekPhysicalConditionGraph.swift */,
 			);
 			path = Graphs;
@@ -345,7 +346,8 @@
 			isa = PBXGroup;
 			children = (
 				2E6E64142B80460400A11DB9 /* PhysicalConditionEntryFormViewModel.swift */,
-				2E0ACDF42B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift */,
+				2E0ACDF42B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift */,
+				2E631C6F2B8972E800B35AAC /* PhysicalConditionGraphModel.swift */,
 				2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */,
 			);
 			path = ViewModels;
@@ -547,10 +549,12 @@
 			isa = PBXGroup;
 			children = (
 				2EE812D12B79904E000B65E5 /* PhysicalConditionEntryForm.swift */,
-				2E0ACDF22B93E42200318BF2 /* TodaysPhysicalConditionListView.swift */,
+				2E0ACDF22B93E42200318BF2 /* DailyPhysicalConditionList.swift */,
 				2E0ACDF92B947DB100318BF2 /* PhysicalConditionEditForm.swift */,
 				2E0ACDFB2B9690F300318BF2 /* PhysicalConditionCreateForm.swift */,
+				2E631C6D2B896F0D00B35AAC /* PhysicalConditionGraph.swift */,
 				2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */,
+				2E6983712B9E767D0076EF4F /* SelectedDatePhysicalConditionGraph.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -610,7 +614,6 @@
 			isa = PBXGroup;
 			children = (
 				2EE812EB2B7A243C000B65E5 /* ActivityEntryAreaViewModel.swift */,
-				2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */,
 				2E6983682B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift */,
 			);
 			path = ViewModels;
@@ -747,11 +750,11 @@
 				2E6E640E2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */,
 				2E0C95DA2B6BC62D00576531 /* CommonButtonView.swift in Sources */,
 				2E0C95CC2B6A7D2F00576531 /* HealthReviewDescriptionView.swift in Sources */,
-				2E631C6E2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift in Sources */,
+				2E631C6E2B896F0D00B35AAC /* PhysicalConditionGraph.swift in Sources */,
 				2E0DA4282B8E10EB004E0185 /* ChartXAxisModifier.swift in Sources */,
 				2EAD063E2B9BEFBE00FBCC21 /* PhysicalConditionDataSourceProtocol.swift in Sources */,
 				2EE812D92B79904E000B65E5 /* PhysicalConditionEntryForm.swift in Sources */,
-				2E0ACDF52B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift in Sources */,
+				2E0ACDF52B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift in Sources */,
 				2E6983652B9C728D0076EF4F /* WeekCondition.swift in Sources */,
 				2E0C95BF2B69208A00576531 /* IntroductionView.swift in Sources */,
 				2E0ACDFC2B9690F300318BF2 /* PhysicalConditionCreateForm.swift in Sources */,
@@ -780,9 +783,9 @@
 				2EE812C92B79016D000B65E5 /* TabButton.swift in Sources */,
 				2ED957C82B86BED1007663AA /* SelectorView.swift in Sources */,
 				2E0DA4212B8C0B1F004E0185 /* PhysicalConditionChartView.swift in Sources */,
-				2E631C702B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift in Sources */,
+				2E631C702B8972E800B35AAC /* PhysicalConditionGraphModel.swift in Sources */,
 				2EE812C82B79016D000B65E5 /* ConditionScreen.swift in Sources */,
-				2E0ACDF32B93E42200318BF2 /* TodaysPhysicalConditionListView.swift in Sources */,
+				2E0ACDF32B93E42200318BF2 /* DailyPhysicalConditionList.swift in Sources */,
 				2EE812C12B790137000B65E5 /* MainView.swift in Sources */,
 				2E0ACDFA2B947DB100318BF2 /* PhysicalConditionEditForm.swift in Sources */,
 				2E631C732B8A180E00B35AAC /* Date+Extensions.swift in Sources */,
@@ -793,6 +796,7 @@
 				2EE812CA2B79016D000B65E5 /* TodayCondition.swift in Sources */,
 				2EE812D82B79904E000B65E5 /* HydrationEntryForm.swift in Sources */,
 				2E0C95C22B6929E600576531 /* OnboardingContentView.swift in Sources */,
+				2E6983722B9E767D0076EF4F /* SelectedDatePhysicalConditionGraph.swift in Sources */,
 				2ED957CB2B86BEF8007663AA /* SelectableItem.swift in Sources */,
 				2E6E64152B80460500A11DB9 /* PhysicalConditionEntryFormViewModel.swift in Sources */,
 				2E0DA4232B8CBD9C004E0185 /* TimeZoneType.swift in Sources */,

--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -34,6 +34,12 @@
 		2E631C702B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */; };
 		2E631C732B8A180E00B35AAC /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C722B8A180E00B35AAC /* Date+Extensions.swift */; };
 		2E631C742B8A180E00B35AAC /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E631C722B8A180E00B35AAC /* Date+Extensions.swift */; };
+		2E6983652B9C728D0076EF4F /* WeekCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6983642B9C728D0076EF4F /* WeekCondition.swift */; };
+		2E6983672B9C73720076EF4F /* WeekPhysicalConditionGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6983662B9C73720076EF4F /* WeekPhysicalConditionGraph.swift */; };
+		2E6983692B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6983682B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift */; };
+		2E69836B2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */; };
+		2E69836D2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */; };
+		2E6983702B9DACC50076EF4F /* DateWithPhysicalCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E69836F2B9DACC50076EF4F /* DateWithPhysicalCondition.swift */; };
 		2E6E640E2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */; };
 		2E6E640F2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */; };
 		2E6E64112B7EDEE900A11DB9 /* StyleConst.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6E64102B7EDEE900A11DB9 /* StyleConst.swift */; };
@@ -129,6 +135,12 @@
 		2E631C6D2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayPhysicalConditionGraph.swift; sourceTree = "<group>"; };
 		2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayPhysicalConditionGraphViewModel.swift; sourceTree = "<group>"; };
 		2E631C722B8A180E00B35AAC /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
+		2E6983642B9C728D0076EF4F /* WeekCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekCondition.swift; sourceTree = "<group>"; };
+		2E6983662B9C73720076EF4F /* WeekPhysicalConditionGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionGraph.swift; sourceTree = "<group>"; };
+		2E6983682B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionGraphViewModel.swift; sourceTree = "<group>"; };
+		2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionListView.swift; sourceTree = "<group>"; };
+		2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekPhysicalConditionListViewModel.swift; sourceTree = "<group>"; };
+		2E69836F2B9DACC50076EF4F /* DateWithPhysicalCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateWithPhysicalCondition.swift; sourceTree = "<group>"; };
 		2E6E640D2B7E37A300A11DB9 /* PhysicalConditionRating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionRating.swift; sourceTree = "<group>"; };
 		2E6E64102B7EDEE900A11DB9 /* StyleConst.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleConst.swift; sourceTree = "<group>"; };
 		2E6E64142B80460400A11DB9 /* PhysicalConditionEntryFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionEntryFormViewModel.swift; sourceTree = "<group>"; };
@@ -307,6 +319,7 @@
 			isa = PBXGroup;
 			children = (
 				2E631C6D2B896F0D00B35AAC /* TodayPhysicalConditionGraph.swift */,
+				2E6983662B9C73720076EF4F /* WeekPhysicalConditionGraph.swift */,
 			);
 			path = Graphs;
 			sourceTree = "<group>";
@@ -320,11 +333,20 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		2E69836E2B9DACBA0076EF4F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				2E69836F2B9DACC50076EF4F /* DateWithPhysicalCondition.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		2E6E64132B8045DC00A11DB9 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
 				2E6E64142B80460400A11DB9 /* PhysicalConditionEntryFormViewModel.swift */,
 				2E0ACDF42B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift */,
+				2E69836C2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -478,6 +500,7 @@
 				2EE812C72B79016D000B65E5 /* TodayCondition.swift */,
 				2EE812E62B79A6F0000B65E5 /* ActivityEntryNavigationLink.swift */,
 				2EE812ED2B7ADE9E000B65E5 /* ActivityEntryArea.swift */,
+				2E6983642B9C728D0076EF4F /* WeekCondition.swift */,
 			);
 			path = Children;
 			sourceTree = "<group>";
@@ -513,6 +536,7 @@
 		2EE812CF2B79904E000B65E5 /* PhysicalCondition */ = {
 			isa = PBXGroup;
 			children = (
+				2E69836E2B9DACBA0076EF4F /* Models */,
 				2E6E64132B8045DC00A11DB9 /* ViewModels */,
 				2EE812D02B79904E000B65E5 /* Views */,
 			);
@@ -526,6 +550,7 @@
 				2E0ACDF22B93E42200318BF2 /* TodaysPhysicalConditionListView.swift */,
 				2E0ACDF92B947DB100318BF2 /* PhysicalConditionEditForm.swift */,
 				2E0ACDFB2B9690F300318BF2 /* PhysicalConditionCreateForm.swift */,
+				2E69836A2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -586,6 +611,7 @@
 			children = (
 				2EE812EB2B7A243C000B65E5 /* ActivityEntryAreaViewModel.swift */,
 				2E631C6F2B8972E800B35AAC /* TodayPhysicalConditionGraphViewModel.swift */,
+				2E6983682B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -726,6 +752,7 @@
 				2EAD063E2B9BEFBE00FBCC21 /* PhysicalConditionDataSourceProtocol.swift in Sources */,
 				2EE812D92B79904E000B65E5 /* PhysicalConditionEntryForm.swift in Sources */,
 				2E0ACDF52B93E9EA00318BF2 /* TodaysPhysicalConditionListViewModel.swift in Sources */,
+				2E6983652B9C728D0076EF4F /* WeekCondition.swift in Sources */,
 				2E0C95BF2B69208A00576531 /* IntroductionView.swift in Sources */,
 				2E0ACDFC2B9690F300318BF2 /* PhysicalConditionCreateForm.swift in Sources */,
 				2EE812DB2B79904E000B65E5 /* ReviewEntryForm.swift in Sources */,
@@ -736,13 +763,18 @@
 				2EE812E02B799E24000B65E5 /* MainTabConst.swift in Sources */,
 				2EFD01862B71A254003020C6 /* WatchFeatureExplanationViewModel.swift in Sources */,
 				2EAD06402B9BF01D00FBCC21 /* PhysicalConditionDataSource+Extension.swift in Sources */,
+				2E6983692B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift in Sources */,
 				2E0C95D72B6B0EBE00576531 /* AppColors.swift in Sources */,
+				2E69836B2B9D554C0076EF4F /* WeekPhysicalConditionListView.swift in Sources */,
+				2E69836D2B9D58BB0076EF4F /* WeekPhysicalConditionListViewModel.swift in Sources */,
+				2E6983672B9C73720076EF4F /* WeekPhysicalConditionGraph.swift in Sources */,
 				2EE812E92B79ABBC000B65E5 /* PlusButton.swift in Sources */,
 				2EE812E52B79A4A0000B65E5 /* ConditionNavigationLink.swift in Sources */,
 				2EE812E32B79A068000B65E5 /* ConditionTab.swift in Sources */,
 				2ED957D12B883D8B007663AA /* PhysicalConditionDataSource.swift in Sources */,
 				2E0C95C82B6A723300576531 /* ReminderExplanationView.swift in Sources */,
 				2E8C66DB2B856F9100280A17 /* StyledTextEditor.swift in Sources */,
+				2E6983702B9DACC50076EF4F /* DateWithPhysicalCondition.swift in Sources */,
 				2EBD2D362B608BDC0063EC7A /* RemoteWellnessSupportApp.swift in Sources */,
 				2E0DA4252B8D5DC4004E0185 /* GraphDefinition.swift in Sources */,
 				2EE812C92B79016D000B65E5 /* TabButton.swift in Sources */,

--- a/RemoteWellnessSupportApp/Activity/Enums/ActivityListDestination.swift
+++ b/RemoteWellnessSupportApp/Activity/Enums/ActivityListDestination.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum ActivityListDestination {
-    case physicalConditionList
+    case todayPhysicalConditionList, weekPhysicalConditionList
 }

--- a/RemoteWellnessSupportApp/Activity/Enums/ActivityListDestination.swift
+++ b/RemoteWellnessSupportApp/Activity/Enums/ActivityListDestination.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
-enum ActivityListDestination {
-    case todayPhysicalConditionList, weekPhysicalConditionList
+enum ActivityListDestination: Hashable {
+    case dailyPhysicalConditionList(Date)
+    case weekPhysicalConditionList
 }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
@@ -1,0 +1,18 @@
+//
+//  DateWithPhysicalCondition.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/10.
+//
+
+import Foundation
+
+struct DateWithPhysicalCondition: Hashable {
+    var date: String
+    var id: UUID
+
+    init(date: String) {
+        self.date = date
+        id = UUID()
+    }
+}

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct DateWithPhysicalCondition: Hashable {
-    var date: String
+    var date: Date
     var id: UUID
 
-    init(date: String) {
+    init(date: Date) {
         self.date = date
         id = UUID()
     }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct DateWithPhysicalCondition: Hashable {
     var date: Date
-    var id: UUID
+    let id: UUID
 
     init(date: Date) {
         self.date = date

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class DailyPhysicalConditionListViewModel: ObservableObject {
     private let dataSource: PhysicalConditionDataSource
-    private let targetDate: Date
+    let targetDate: Date
     @Published var physicalConditions: [PhysicalCondition] = []
     @Published var isErrorAlert = false
     @Published var errorMessage = ""

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  TodaysPhysicalConditionListViewModel.swift
+//  DailyPhysicalConditionListViewModel.swift
 //  RemoteWellnessSupportApp
 //
 //  Created by 岩本雄貴 on 2024/03/03.
@@ -7,19 +7,21 @@
 
 import Foundation
 
-class TodaysPhysicalConditionListViewModel: ObservableObject {
+class DailyPhysicalConditionListViewModel: ObservableObject {
     private let dataSource: PhysicalConditionDataSource
+    private let targetDate: Date
     @Published var physicalConditions: [PhysicalCondition] = []
     @Published var isErrorAlert = false
     @Published var errorMessage = ""
 
-    init(dataSource: PhysicalConditionDataSource = .shared) {
+    init(dataSource: PhysicalConditionDataSource = .shared, targetDate: Date = Date()) {
         self.dataSource = dataSource
+        self.targetDate = targetDate
     }
 
     func fetchPhysicalConditions() {
         do {
-            let predicate = createPredicateForToday()
+            let predicate = createPredicateForTargetDate()
             let sortBy = [SortDescriptor(\PhysicalCondition.entryDate)]
             physicalConditions = try dataSource.fetchPhysicalConditions(predicate: predicate, sortBy: sortBy)
         } catch {
@@ -36,11 +38,13 @@ class TodaysPhysicalConditionListViewModel: ObservableObject {
         }
     }
 
-    private func createPredicateForToday() -> Predicate<PhysicalCondition> {
+    private func createPredicateForTargetDate() -> Predicate<PhysicalCondition> {
         let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: Date())
+        let startOfDay = calendar.startOfDay(for: targetDate)
+        let endOfDayComponents = DateComponents(day: 1)
+        let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay)!
         let predicate = #Predicate<PhysicalCondition> { physicalCondition in
-            physicalCondition.entryDate >= startOfDay
+            physicalCondition.entryDate >= startOfDay && physicalCondition.entryDate < endOfDay
         }
         return predicate
     }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
@@ -42,7 +42,9 @@ class DailyPhysicalConditionListViewModel: ObservableObject {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: targetDate)
         let endOfDayComponents = DateComponents(day: 1)
-        let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay)!
+        guard let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay) else {
+            fatalError("Failed to calculate the end of day")
+        }
         let predicate = #Predicate<PhysicalCondition> { physicalCondition in
             physicalCondition.entryDate >= startOfDay && physicalCondition.entryDate < endOfDay
         }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionGraphModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionGraphModel.swift
@@ -58,7 +58,10 @@ class PhysicalConditionGraphModel: ObservableObject {
         let calendar = Calendar.current
         let currentHour = calendar.component(.hour, from: targetDate)
         // TODO: 現在はhoursRangeを特定値で固定にしているが別途、ここも動的になる
-        let hoursRange: Range<Int> = (currentHour > 0 && currentHour < 9) ? 0 ..< currentHour + 1 : 9 ..< 19
+        let startHour = 0
+        let endHour = 9
+        let defaultEndHour = 19
+        let hoursRange: Range<Int> = (currentHour > startHour && currentHour < endHour) ? startHour ..< currentHour + 1 : endHour ..< defaultEndHour
 
         for hour in hoursRange {
             let averageRating = calculateAverageRatingForHour(conditions, hour: hour)

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionGraphModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionGraphModel.swift
@@ -38,7 +38,9 @@ class PhysicalConditionGraphModel: ObservableObject {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: targetDate)
         let endOfDayComponents = DateComponents(day: 1)
-        let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay)!
+        guard let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay) else {
+            fatalError("Failed to calculate the end of day")
+        }
         let predicate = #Predicate<PhysicalCondition> { physicalCondition in
             physicalCondition.entryDate >= startOfDay && physicalCondition.entryDate < endOfDay
         }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
@@ -45,7 +45,7 @@ class WeekPhysicalConditionListViewModel: ObservableObject {
         let sortedDates = groupedConditions.keys.sorted()
 
         let dateWithPhysicalCondition: [DateWithPhysicalCondition] = sortedDates.map { date -> DateWithPhysicalCondition in
-            DateWithPhysicalCondition(date: date.toString(format: "yyyy/MM/dd"))
+            DateWithPhysicalCondition(date: date)
         }
 
         return dateWithPhysicalCondition

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
@@ -55,7 +55,7 @@ class WeekPhysicalConditionListViewModel: ObservableObject {
         let currentTime = Date()
         let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: currentTime)
         let predicate = #Predicate<PhysicalCondition> { physicalCondition in
-            physicalCondition.entryDate > (oneWeekAgo ?? currentTime)
+            physicalCondition.entryDate > oneWeekAgo!
         }
         return predicate
     }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  WeekPhysicalConditionListViewModel.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/10.
+//
+
+import Foundation
+
+class WeekPhysicalConditionListViewModel: ObservableObject {
+    private let dataSource: PhysicalConditionDataSource
+    @Published var dateWithPhysicalConditions: [DateWithPhysicalCondition] = []
+    @Published var isErrorAlert = false
+    @Published var errorMessage = ""
+
+    init(dataSource: PhysicalConditionDataSource = .shared) {
+        self.dataSource = dataSource
+    }
+
+    func fetchDatesWithPhysicalCondition() {
+        do {
+            let predicate = createPredicateForRecentOneWeekPhysicalConditions()
+
+            let physicalConditions = try dataSource.fetchPhysicalConditions(predicate: predicate)
+            assignWeekPhysicalConditions(physicalConditions)
+        } catch {
+            setError(withMessage: "体調データの取得に失敗しました")
+        }
+    }
+
+    private func assignWeekPhysicalConditions(_ physicalConditions: [PhysicalCondition]) {
+        if physicalConditions.isEmpty {
+            dateWithPhysicalConditions = []
+        } else {
+            dateWithPhysicalConditions = convertToDateWithPhysicalConditions(physicalConditions)
+        }
+    }
+
+    private func convertToDateWithPhysicalConditions(_ conditions: [PhysicalCondition]) -> [DateWithPhysicalCondition] {
+        let calendar = Calendar.current
+        let groupedConditions = Dictionary(grouping: conditions) { condition -> Date in
+            calendar.startOfDay(for: condition.entryDate)
+        }
+
+        let sortedDates = groupedConditions.keys.sorted()
+
+        let dateWithPhysicalCondition: [DateWithPhysicalCondition] = sortedDates.map { date -> DateWithPhysicalCondition in
+            DateWithPhysicalCondition(date: date.toString(format: "yyyy/MM/dd"))
+        }
+
+        return dateWithPhysicalCondition
+    }
+
+    private func createPredicateForRecentOneWeekPhysicalConditions() -> Predicate<PhysicalCondition> {
+        let currentTime = Date()
+        let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: currentTime)
+        let predicate = #Predicate<PhysicalCondition> { physicalCondition in
+            physicalCondition.entryDate > (oneWeekAgo ?? currentTime)
+        }
+        return predicate
+    }
+
+    private func setError(withMessage message: String) {
+        isErrorAlert = true
+        errorMessage = message
+    }
+}

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/DailyPhysicalConditionList.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/DailyPhysicalConditionList.swift
@@ -1,5 +1,5 @@
 //
-//  TodaysPhysicalConditionListView.swift
+//  DailyPhysicalConditionList.swift
 //  RemoteWellnessSupportApp
 //
 //  Created by 岩本雄貴 on 2024/03/03.
@@ -7,11 +7,17 @@
 
 import SwiftUI
 
-struct TodaysPhysicalConditionListView: View {
-    @StateObject var viewModel = TodaysPhysicalConditionListViewModel()
+struct DailyPhysicalConditionList: View {
+    let targetDate: Date
+    @StateObject var viewModel: DailyPhysicalConditionListViewModel
+
+    init(targetDate: Date) {
+        self.targetDate = targetDate
+        _viewModel = StateObject(wrappedValue: DailyPhysicalConditionListViewModel(targetDate: targetDate))
+    }
 
     var body: some View {
-        Text("体調一覧 \(Date().toString(format: "MM/dd"))")
+        Text("体調一覧 \(targetDate.toString(format: "MM/dd"))")
         content
             .modifier(ErrorAlertModifier(isErrorAlert: $viewModel.isErrorAlert, errorMessage: $viewModel.errorMessage))
             .navigationDestination(for: PhysicalCondition.self) { selectedCondition in
@@ -53,6 +59,6 @@ struct TodaysPhysicalConditionListView: View {
     }
 }
 
-#Preview {
-    TodaysPhysicalConditionListView()
-}
+// #Preview {
+//    SelectedDatePhysicalConditionListView()
+// }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/DailyPhysicalConditionList.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/DailyPhysicalConditionList.swift
@@ -11,7 +11,7 @@ struct DailyPhysicalConditionList: View {
     let targetDate: Date
     @StateObject var viewModel: DailyPhysicalConditionListViewModel
 
-    init(targetDate: Date) {
+    init(targetDate: Date = Date()) {
         self.targetDate = targetDate
         _viewModel = StateObject(wrappedValue: DailyPhysicalConditionListViewModel(targetDate: targetDate))
     }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionGraph.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionGraph.swift
@@ -1,5 +1,5 @@
 //
-//  TodayPhysicalConditionGraph.swift
+//  PhysicalConditionGraph.swift
 //  RemoteWellnessSupportApp
 //
 //  Created by 岩本雄貴 on 2024/02/24.
@@ -8,8 +8,14 @@
 import Charts
 import SwiftUI
 
-struct TodayPhysicalConditionGraph: View {
-    @StateObject private var viewModel = TodayPhysicalConditionGraphViewModel()
+struct PhysicalConditionGraph: View {
+    let targetDate: Date
+    @StateObject private var viewModel: PhysicalConditionGraphModel
+
+    init(targetDate: Date) {
+        self.targetDate = targetDate
+        _viewModel = StateObject(wrappedValue: PhysicalConditionGraphModel(targetDate: targetDate))
+    }
 
     var body: some View {
         VStack(alignment: .center, spacing: 15) {
@@ -26,7 +32,7 @@ struct TodayPhysicalConditionGraph: View {
     @ViewBuilder
     private var content: some View {
         if viewModel.todayPhysicalConditions.isEmpty {
-            Text("本日の体調のデータはありません。")
+            Text("体調のデータはありません。")
             Spacer()
         } else {
             PhysicalConditionChartView(physicalConditions: viewModel.todayPhysicalConditions, timeZoneType: TimeZoneType.hour)
@@ -34,6 +40,6 @@ struct TodayPhysicalConditionGraph: View {
     }
 }
 
-#Preview {
-    TodayPhysicalConditionGraph()
-}
+// #Preview {
+//    TodayPhysicalConditionGraph()
+// }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
@@ -1,0 +1,30 @@
+//
+//  SelectedDatePhysicalConditionGraph.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/11.
+//
+
+import SwiftUI
+
+struct SelectedDatePhysicalConditionGraph: View {
+    let targetDate: Date
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                Text("\(targetDate.toString(format: "yyyy/MM/dd"))")
+                    .font(.title3)
+                NavigationLink(value: ActivityListDestination.dailyPhysicalConditionList(targetDate)) {
+                    PhysicalConditionGraph(targetDate: targetDate)
+                        .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+// #Preview {
+//    SelectedDatePhysicalConditionGraph()
+// }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
@@ -1,0 +1,44 @@
+//
+//  WeekPhysicalConditionListView.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/10.
+//
+
+import SwiftUI
+
+struct WeekPhysicalConditionListView: View {
+    @StateObject var viewModel = WeekPhysicalConditionListViewModel()
+
+    var body: some View {
+        Text("体調一覧")
+        content
+            .onAppear {
+                viewModel.fetchDatesWithPhysicalCondition()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.dateWithPhysicalConditions.isEmpty {
+            Text("データがありません")
+            Spacer()
+        } else {
+            List {
+                ForEach(viewModel.dateWithPhysicalConditions, id: \.self) { item in
+                    HStack {
+                        // TODO: 後でnavigation対応を実施
+                        // NavigationLink(value: item) {
+                        Text(item.date)
+                        Spacer()
+                        // }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    WeekPhysicalConditionListView()
+}

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct WeekPhysicalConditionListView: View {
-    @StateObject var viewModel = WeekPhysicalConditionListViewModel()
+    @ObservedObject var viewModel: WeekPhysicalConditionListViewModel
+
+    init(viewModel: WeekPhysicalConditionListViewModel = WeekPhysicalConditionListViewModel()) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         Text("体調一覧")

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
@@ -13,6 +13,9 @@ struct WeekPhysicalConditionListView: View {
     var body: some View {
         Text("体調一覧")
         content
+            .navigationDestination(for: DateWithPhysicalCondition.self) { dateWithPhysicalCondition in
+                SelectedDatePhysicalConditionGraph(targetDate: dateWithPhysicalCondition.date)
+            }
             .onAppear {
                 viewModel.fetchDatesWithPhysicalCondition()
             }
@@ -27,11 +30,10 @@ struct WeekPhysicalConditionListView: View {
             List {
                 ForEach(viewModel.dateWithPhysicalConditions, id: \.self) { item in
                     HStack {
-                        // TODO: 後でnavigation対応を実施
-                        // NavigationLink(value: item) {
-                        Text(item.date)
-                        Spacer()
-                        // }
+                        NavigationLink(value: item) {
+                            Text(item.date.toString(format: "yyyy/MM/dd"))
+                            Spacer()
+                        }
                     }
                 }
             }

--- a/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
+++ b/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
@@ -14,4 +14,10 @@ extension Date {
         formatter.locale = Locale(identifier: "ja_JP")
         return formatter.string(from: self)
     }
+
+    func toDateFormDateString(format: String = "yyyy/MM/dd HH:mm:ss", value: String) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = format
+        return dateFormatter.date(from: value) ?? Date()
+    }
 }

--- a/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
+++ b/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
@@ -11,6 +11,7 @@ extension Date {
     func toString(format: String = "yyyy/MM/dd HH:mm:ss") -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
+        formatter.locale = Locale(identifier: "ja_JP")
         return formatter.string(from: self)
     }
 }

--- a/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
+++ b/RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
@@ -14,10 +14,4 @@ extension Date {
         formatter.locale = Locale(identifier: "ja_JP")
         return formatter.string(from: self)
     }
-
-    func toDateFormDateString(format: String = "yyyy/MM/dd HH:mm:ss", value: String) -> Date {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = format
-        return dateFormatter.date(from: value) ?? Date()
-    }
 }

--- a/RemoteWellnessSupportApp/Condition/Enums/GraphDefinition.swift
+++ b/RemoteWellnessSupportApp/Condition/Enums/GraphDefinition.swift
@@ -15,6 +15,6 @@ enum GraphDefinition {
 
     enum TimeZone: String {
         case hour = "H"
-        case date = "MM/dd"
+        case date = "EEEE"
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/WeekPhysicalConditionGraphViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/WeekPhysicalConditionGraphViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  WeekPhysicalConditionGraphViewModel.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/09.
+//
+
+import Foundation
+
+class WeekPhysicalConditionGraphViewModel: ObservableObject {
+    private let dataSource: PhysicalConditionDataSource
+
+    @Published var isErrorAlert = false
+    @Published var errorMessage = ""
+
+    init(dataSource: PhysicalConditionDataSource = .shared) {
+        self.dataSource = dataSource
+    }
+
+    @Published var weekPhysicalConditions: [GraphPhysicalCondition] = []
+
+    func fetchWeekPhysicalConditions() {
+        do {
+            let predicate = createPredicateForRecentOneWeekPhysicalConditions()
+
+            let physicalConditions = try dataSource.fetchPhysicalConditions(predicate: predicate)
+            assignWeekPhysicalConditions(physicalConditions)
+        } catch {
+            setError(withMessage: "体調データの取得に失敗しました")
+        }
+    }
+
+    private func createPredicateForRecentOneWeekPhysicalConditions() -> Predicate<PhysicalCondition> {
+        let currentTime = Date()
+        let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: currentTime)
+        let predicate = #Predicate<PhysicalCondition> { physicalCondition in
+            physicalCondition.entryDate > (oneWeekAgo ?? currentTime)
+        }
+        return predicate
+    }
+
+    private func assignWeekPhysicalConditions(_ physicalConditions: [PhysicalCondition]) {
+        if physicalConditions.isEmpty {
+            weekPhysicalConditions = []
+        } else {
+            weekPhysicalConditions = convertToGraphPhysicalConditions(physicalConditions)
+        }
+    }
+
+    private func convertToGraphPhysicalConditions(_ conditions: [PhysicalCondition]) -> [GraphPhysicalCondition] {
+        let calendar = Calendar.current
+        let currentTime = Date()
+        let dateRange = (0 ... 7).map { date -> Date in
+            calendar.startOfDay(for: calendar.date(byAdding: .day, value: -date, to: currentTime)!)
+        }
+
+        let groupedConditions = Dictionary(grouping: conditions) { condition -> Date in
+            calendar.startOfDay(for: condition.entryDate)
+        }
+
+        let graphConditions: [GraphPhysicalCondition] = dateRange.map { date -> GraphPhysicalCondition in
+            if let conditionsForDay = groupedConditions[date] {
+                let averageRating = conditionsForDay.reduce(0) { $0 + $1.rating } / conditionsForDay.count
+                return GraphPhysicalCondition(timeZone: date, rateAverage: averageRating)
+            } else {
+                return GraphPhysicalCondition(timeZone: date, rateAverage: 0)
+            }
+        }
+
+        return graphConditions
+    }
+
+    private func setError(withMessage message: String) {
+        isErrorAlert = true
+        errorMessage = message
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/WeekPhysicalConditionGraphViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/WeekPhysicalConditionGraphViewModel.swift
@@ -51,7 +51,10 @@ class WeekPhysicalConditionGraphViewModel: ObservableObject {
         let calendar = Calendar.current
         let currentTime = Date()
         let dateRange = (0 ... 7).map { date -> Date in
-            calendar.startOfDay(for: calendar.date(byAdding: .day, value: -date, to: currentTime)!)
+            guard let startOfDay = calendar.date(byAdding: .day, value: -date, to: currentTime) else {
+                fatalError("Failed to calculate start of day")
+            }
+            return calendar.startOfDay(for: startOfDay)
         }
 
         let groupedConditions = Dictionary(grouping: conditions) { condition -> Date in

--- a/RemoteWellnessSupportApp/Condition/Views/Children/Graphs/WeekPhysicalConditionGraph.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/Graphs/WeekPhysicalConditionGraph.swift
@@ -1,0 +1,38 @@
+//
+//  WeekPhysicalConditionGraph.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/03/09.
+//
+
+import SwiftUI
+
+struct WeekPhysicalConditionGraph: View {
+    @StateObject private var viewModel = WeekPhysicalConditionGraphViewModel()
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 15) {
+            Text("体調")
+                .font(.title3)
+            content
+                .modifier(ErrorAlertModifier(isErrorAlert: $viewModel.isErrorAlert, errorMessage: $viewModel.errorMessage))
+                .onAppear {
+                    viewModel.fetchWeekPhysicalConditions()
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.weekPhysicalConditions.isEmpty {
+            Text("この1週間の体調のデータはありません。")
+            Spacer()
+        } else {
+            PhysicalConditionChartView(physicalConditions: viewModel.weekPhysicalConditions, timeZoneType: TimeZoneType.date)
+        }
+    }
+}
+
+#Preview {
+    WeekPhysicalConditionGraph()
+}

--- a/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
@@ -13,15 +13,15 @@ struct TodayCondition: View {
             ZStack {
                 ScrollView {
                     VStack(spacing: StyleConst.Spacing.defaultSpacing) {
-                        NavigationLink(value: ActivityListDestination.todayPhysicalConditionList) {
-                            TodayPhysicalConditionGraph()
+                        NavigationLink(value: ActivityListDestination.dailyPhysicalConditionList(Date())) {
+                            PhysicalConditionGraph(targetDate: Date())
                                 .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
                                 .padding()
                         }
                     }
                     .navigationDestination(for: ActivityListDestination.self) { _ in
 
-                        TodaysPhysicalConditionListView()
+                        DailyPhysicalConditionList(targetDate: Date())
                     }
                 }
                 ActivityEntryArea()

--- a/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 struct TodayCondition: View {
+    let today = Date()
     var body: some View {
         GeometryReader { geometry in
             ZStack {
                 ScrollView {
                     VStack(spacing: StyleConst.Spacing.defaultSpacing) {
-                        NavigationLink(value: ActivityListDestination.dailyPhysicalConditionList(Date())) {
-                            PhysicalConditionGraph(targetDate: Date())
+                        NavigationLink(value: ActivityListDestination.dailyPhysicalConditionList(today)) {
+                            PhysicalConditionGraph(targetDate: today)
                                 .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
                                 .padding()
                         }

--- a/RemoteWellnessSupportApp/Condition/Views/Children/WeekCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/WeekCondition.swift
@@ -19,8 +19,14 @@ struct WeekCondition: View {
                                 .padding()
                         }
                     }
-                    .navigationDestination(for: ActivityListDestination.self) { _ in
-                        WeekPhysicalConditionListView()
+                    .frame(maxWidth: .infinity)
+                    .navigationDestination(for: ActivityListDestination.self) { destination in
+                        switch destination {
+                        case let .dailyPhysicalConditionList(targetDate):
+                            DailyPhysicalConditionList(targetDate: targetDate)
+                        case .weekPhysicalConditionList:
+                            WeekPhysicalConditionListView()
+                        }
                     }
                 }
             }

--- a/RemoteWellnessSupportApp/Condition/Views/Children/WeekCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/WeekCondition.swift
@@ -1,35 +1,33 @@
 //
-//  TodayCondition.swift
+//  WeekCondition.swift
 //  RemoteWellnessSupportApp
 //
-//  Created by 岩本雄貴 on 2024/02/03.
+//  Created by 岩本雄貴 on 2024/03/09.
 //
 
 import SwiftUI
 
-struct TodayCondition: View {
+struct WeekCondition: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
                 ScrollView {
                     VStack(spacing: StyleConst.Spacing.defaultSpacing) {
-                        NavigationLink(value: ActivityListDestination.todayPhysicalConditionList) {
-                            TodayPhysicalConditionGraph()
+                        NavigationLink(value: ActivityListDestination.weekPhysicalConditionList) {
+                            WeekPhysicalConditionGraph()
                                 .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
                                 .padding()
                         }
                     }
                     .navigationDestination(for: ActivityListDestination.self) { _ in
-
-                        TodaysPhysicalConditionListView()
+                        WeekPhysicalConditionListView()
                     }
                 }
-                ActivityEntryArea()
             }
         }
     }
 }
 
 #Preview {
-    TodayCondition()
+    WeekCondition()
 }

--- a/RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
@@ -23,8 +23,7 @@ struct ConditionScreen: View {
             case .today:
                 TodayCondition()
             case .week:
-                // TODO: 現状はダミーで作成、WeekTabView作成時に対応
-                Text("Week View")
+                WeekCondition()
             }
 
             Spacer()


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- `ActivityListDestination` enumに新しいケースを追加し、Hashableを実装。
- 特定の日付の体調データを取得・表示するためのモデル、ビューモデル、ビューを追加。
- 過去1週間の体調データの日付一覧とグラフ表示機能を追加。
- `Date`拡張に文字列から`Date`への変換メソッドを追加。
- グラフ表示の時間軸の表示形式を変更。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ActivityListDestination.swift</strong><dd><code>ActivityListDestination enumの更新と拡張</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/Enums/ActivityListDestination.swift
<li><code>ActivityListDestination</code> <br>enumに<code>Hashable</code>を実装し、<code>dailyPhysicalConditionList(Date)</code>と<code>weekPhysicalConditionList</code>ケースを追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-f3b6eafc0453bfe54b5da1b94bf200dab67b7862e29bea679d0956126c088f73">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DateWithPhysicalCondition.swift</strong><dd><code>DateWithPhysicalCondition構造体の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Models/DateWithPhysicalCondition.swift
- 新しい`DateWithPhysicalCondition`構造体を追加。日付と一意のIDを持つ。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-0bc816d42b6e08d57a01b31a2603aca6e795a12c730d01b6076c219ac330b339">+18/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DailyPhysicalConditionListViewModel.swift</strong><dd><code>特定の日付の体調データ取得機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/DailyPhysicalConditionListViewModel.swift
<br><li><code>TodaysPhysicalConditionListViewModel</code>から<code>DailyPhysicalConditionListViewModel</code>に名前を変更し、特定の日付の体調データを取得する機能を追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-735a6a6b11ced65d9ae73efce9b3185f4d7e399a018045f5d40a4cb86a79ebdd">+11/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PhysicalConditionGraphModel.swift</strong><dd><code>特定の日付の体調データグラフ表示機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionGraphModel.swift
<br><li><code>TodayPhysicalConditionGraphViewModel</code>から<code>PhysicalConditionGraphModel</code>に名前を変更し、特定の日付の体調データをグラフ表示する機能を追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-823d4cbcea7bcbc44a339bb86698d740ec6838bb5d1e35c57dc27e188ccaa476">+14/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WeekPhysicalConditionListViewModel.swift</strong><dd><code>過去1週間の体調データ日付取得機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/WeekPhysicalConditionListViewModel.swift
<li>新しい<code>WeekPhysicalConditionListViewModel</code>を追加し、過去1週間の体調データの日付を取得する機能を実装。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-1bf52b2c98ef7e8a52663ee11fd7515fc2abfbfa03c4858ecbeb00e811b50eca">+67/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DailyPhysicalConditionList.swift</strong><dd><code>特定の日付の体調一覧ビューへの変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/DailyPhysicalConditionList.swift
<br><li><code>TodaysPhysicalConditionListView</code>から<code>DailyPhysicalConditionList</code>に名前を変更し、特定の日付を引数に取るように変更。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-b2acd3fbb532ca1bd645b6192dfaebb9c34d7fb63295dbd1007efc92cf778bf2">+13/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PhysicalConditionGraph.swift</strong><dd><code>特定の日付の体調データグラフ表示ビューへの変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionGraph.swift
<br><li><code>TodayPhysicalConditionGraph</code>から<code>PhysicalConditionGraph</code>に名前を変更し、特定の日付の体調データをグラフ表示する機能を追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-ed45a13b024f7a3a73fe1f84eae18e4fdee40a1f5491edce0ad782e1bcb542f4">+13/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SelectedDatePhysicalConditionGraph.swift</strong><dd><code>特定の日付選択時の体調データグラフ表示ビューの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
- 特定の日付を選択した際の体調データグラフ表示ビュー`SelectedDatePhysicalConditionGraph`を新規追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-72325ab28537dc50bde65152c5c7408bf2c34b153c99c25fd1dda70b9a4f266c">+30/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WeekPhysicalConditionListView.swift</strong><dd><code>過去1週間の体調データ日付一覧ビューの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/WeekPhysicalConditionListView.swift
- 過去1週間の体調データの日付一覧を表示するビュー`WeekPhysicalConditionListView`を新規追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-883d2d7370961ca486361f09699236f2cc3b702f8a5143d54c2bbe390a561b14">+46/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Date+Extensions.swift</strong><dd><code>Date拡張への文字列からDateへの変換メソッドの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Common/Extensions/Date+Extensions.swift
- `Date`拡張に日付文字列を`Date`オブジェクトに変換する`toDateFormDateString`メソッドを追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-4a110996a937237329b198bf0f969ce8eccc8195fa83f337297bda92d6ced82f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GraphDefinition.swift</strong><dd><code>グラフの時間軸表示形式の変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Enums/GraphDefinition.swift
- `GraphDefinition.TimeZone` enumに`date`ケースの表示形式を`"EEEE"`に変更。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-7a13ac49206973cef38ae459d6b5dff9bfa16cd001705d2c40b38d87dbd486a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WeekPhysicalConditionGraphViewModel.swift</strong><dd><code>過去1週間の体調データグラフ表示機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/WeekPhysicalConditionGraphViewModel.swift
<li>新しい<code>WeekPhysicalConditionGraphViewModel</code>を追加し、過去1週間の体調データをグラフ表示する機能を実装。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-a3fea89f0304792f92abed8785e1933bf6585b1b5956b2950125e5d804fe7124">+77/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WeekPhysicalConditionGraph.swift</strong><dd><code>過去1週間の体調データグラフ表示ビューの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/Children/Graphs/WeekPhysicalConditionGraph.swift
- 過去1週間の体調データをグラフ表示するビュー`WeekPhysicalConditionGraph`を新規追加。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-104f64cfb8afa6c33362c08b109f8548e5d6c436e706eaf51514dde143f476c8">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TodayCondition.swift</strong><dd><code>今日の体調ビューの更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
- `TodayCondition`ビューで`PhysicalConditionGraph`を使用するように変更。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-c321ea6ac17951e8ab53f506954458cb841093ef0368706c411711dad043e164">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WeekCondition.swift</strong><dd><code>過去1週間の体調ビューの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/Children/WeekCondition.swift
- 新しい`WeekCondition`ビューを追加し、過去1週間の体調データとグラフを表示。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-2fdd0cd852a0d5defddfbb09fc2a4f30e1ac340a732d426b061d6f92f6908e47">+39/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ConditionScreen.swift</strong><dd><code>条件画面ビューの更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
- `ConditionScreen`ビューで`WeekCondition`ビューを表示するように変更。


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/12/files#diff-df47fcea3c054f11d859d339b73b9e5970fe3aed2da8ba3acfd0c9ff3916333f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - 特定の日付の物理状態データを表示するための新しいグラフコンポーネントが導入されました。

- **機能改善**
    - 物理状態に関連するエンティティ名が「Today」から「Daily」に変更され、週間の物理状態を管理する新しいエンティティが追加されました。

- **バグ修正**
    - 物理状態情報の表示に関連する機能が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->