### PR TITLE
feat: 各日付のグラフ画面から新規登録画面に遷移できるように修正

### DIFF
--- a/RemoteWellnessSupportApp/Activity/Hydration/ViewModels/HydrationEntryFormViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/ViewModels/HydrationEntryFormViewModel.swift
@@ -14,7 +14,7 @@ class HydrationEntryFormViewModel: BaseViewModel {
     let targetDate: Date
 
     init(dataSource: HydrationDataSource = HydrationDataSource.shared, action: FormAction = .create,
-         hydration: Hydration? = nil, targetDate: Date = Date()) {
+         hydration: Hydration? = nil, targetDate: Date) {
         self.dataSource = dataSource
         self.action = action
         self.hydration = hydration

--- a/RemoteWellnessSupportApp/Activity/Hydration/ViewModels/HydrationEntryFormViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/ViewModels/HydrationEntryFormViewModel.swift
@@ -11,11 +11,14 @@ class HydrationEntryFormViewModel: BaseViewModel {
     private let dataSource: HydrationDataSource
     private let action: FormAction
     private let hydration: Hydration?
+    let targetDate: Date
 
-    init(dataSource: HydrationDataSource = HydrationDataSource.shared, action: FormAction = .create, hydration: Hydration? = nil) {
+    init(dataSource: HydrationDataSource = HydrationDataSource.shared, action: FormAction = .create,
+         hydration: Hydration? = nil, targetDate: Date = Date()) {
         self.dataSource = dataSource
         self.action = action
         self.hydration = hydration
+        self.targetDate = targetDate
 
         super.init()
         setFormInitialValue()
@@ -75,7 +78,10 @@ class HydrationEntryFormViewModel: BaseViewModel {
     }
 
     private func setFormInitialValue() {
-        guard let item = hydration else { return }
+        guard let item = hydration else {
+            selectedDateTime = targetDate
+            return
+        }
         selectedDateTime = item.entryDate
         selectedRating = HydrationRating(rawValue: item.rating)
     }

--- a/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationCreateForm.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationCreateForm.swift
@@ -8,12 +8,15 @@
 import SwiftUI
 
 struct HydrationCreateForm: View {
+    let targetDate: Date
     @StateObject var viewModel = HydrationEntryFormViewModel()
+
+    init(targetDate: Date = Date()) {
+        self.targetDate = targetDate
+        _viewModel = StateObject(wrappedValue: HydrationEntryFormViewModel(targetDate: targetDate))
+    }
+
     var body: some View {
         HydrationEntryForm(viewModel: viewModel, title: "水分登録")
     }
-}
-
-#Preview {
-    HydrationCreateForm()
 }

--- a/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationCreateForm.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationCreateForm.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HydrationCreateForm: View {
     let targetDate: Date
-    @StateObject var viewModel = HydrationEntryFormViewModel()
+    @StateObject var viewModel: HydrationEntryFormViewModel
 
     init(targetDate: Date = Date()) {
         self.targetDate = targetDate

--- a/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationEditForm.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationEditForm.swift
@@ -14,7 +14,7 @@ struct HydrationEditForm: View {
     init(hydration: Hydration) {
         self.hydration = hydration
         _viewModel = StateObject(wrappedValue:
-            HydrationEntryFormViewModel(action: .update, hydration: hydration))
+            HydrationEntryFormViewModel(action: .update, hydration: hydration, targetDate: hydration.entryDate))
     }
 
     var body: some View {

--- a/RemoteWellnessSupportApp/Activity/Hydration/Views/SelectedDateHydrationGraph.swift
+++ b/RemoteWellnessSupportApp/Activity/Hydration/Views/SelectedDateHydrationGraph.swift
@@ -9,15 +9,19 @@ import SwiftUI
 
 struct SelectedDateHydrationGraph: View {
     let targetDate: Date
+    @EnvironmentObject var router: ConditionScreenNavigationRouter
 
     var body: some View {
         GeometryReader { geometry in
-            VStack {
+            VStack(spacing: 40) {
                 Text("\(targetDate.toString(format: "yyyy/MM/dd"))")
                     .font(.title3)
                 NavigationLink(value: ConditionScreenNavigationItem.dailyHydrationList(date: targetDate)) {
                     HydrationGraph(targetDate: targetDate)
                         .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
+                }
+                CommonButtonView(title: "新規登録") {
+                    router.items.append(.hydrationEntryForm(date: targetDate))
                 }
             }
             .frame(maxWidth: .infinity)

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionEntryFormViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionEntryFormViewModel.swift
@@ -15,7 +15,7 @@ class PhysicalConditionEntryFormViewModel: ObservableObject {
     let targetDate: Date
 
     init(formAction: FormAction = .create, physicalCondition: PhysicalCondition? = nil,
-         dataSource: PhysicalConditionDataSourceProtocol = PhysicalConditionDataSource.shared, targetDate: Date = Date()) {
+         dataSource: PhysicalConditionDataSourceProtocol = PhysicalConditionDataSource.shared, targetDate: Date) {
         self.dataSource = dataSource
         action = formAction
         self.physicalCondition = physicalCondition

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionEntryFormViewModel.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionEntryFormViewModel.swift
@@ -12,12 +12,14 @@ class PhysicalConditionEntryFormViewModel: ObservableObject {
     private let dataSource: PhysicalConditionDataSourceProtocol
     private let action: FormAction
     private let physicalCondition: PhysicalCondition?
+    let targetDate: Date
 
     init(formAction: FormAction = .create, physicalCondition: PhysicalCondition? = nil,
-         dataSource: PhysicalConditionDataSourceProtocol = PhysicalConditionDataSource.shared) {
+         dataSource: PhysicalConditionDataSourceProtocol = PhysicalConditionDataSource.shared, targetDate: Date = Date()) {
         self.dataSource = dataSource
         action = formAction
         self.physicalCondition = physicalCondition
+        self.targetDate = targetDate
 
         setFormInitialValue()
     }
@@ -80,7 +82,10 @@ class PhysicalConditionEntryFormViewModel: ObservableObject {
     }
 
     private func setFormInitialValue() {
-        guard let item = physicalCondition else { return }
+        guard let item = physicalCondition else {
+            selectedDateTime = targetDate
+            return
+        }
         selectedDateTime = item.entryDate
         memo = item.memo
         selectedRating = PhysicalConditionRating(rawValue: item.rating)

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionCreateForm.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionCreateForm.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct PhysicalConditionCreateForm: View {
+    let targetDate: Date
     @StateObject var viewModel = PhysicalConditionEntryFormViewModel()
+
+    init(targetDate: Date = Date()) {
+        self.targetDate = targetDate
+        _viewModel = StateObject(wrappedValue: PhysicalConditionEntryFormViewModel(targetDate: targetDate))
+    }
 
     var body: some View {
         PhysicalConditionEntryForm(viewModel: viewModel, title: "体調登録")
     }
-}
-
-#Preview {
-    PhysicalConditionCreateForm()
 }

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionCreateForm.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionCreateForm.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PhysicalConditionCreateForm: View {
     let targetDate: Date
-    @StateObject var viewModel = PhysicalConditionEntryFormViewModel()
+    @StateObject var viewModel: PhysicalConditionEntryFormViewModel
 
     init(targetDate: Date = Date()) {
         self.targetDate = targetDate

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionEditForm.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionEditForm.swift
@@ -13,7 +13,11 @@ struct PhysicalConditionEditForm: View {
 
     init(physicalCondition: PhysicalCondition) {
         self.physicalCondition = physicalCondition
-        _viewModel = StateObject(wrappedValue: PhysicalConditionEntryFormViewModel(formAction: .update, physicalCondition: physicalCondition))
+        _viewModel = StateObject(
+            wrappedValue:
+            PhysicalConditionEntryFormViewModel(formAction: .update,
+                                                physicalCondition: physicalCondition,
+                                                targetDate: physicalCondition.entryDate))
     }
 
     var body: some View {

--- a/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
+++ b/RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
@@ -9,22 +9,22 @@ import SwiftUI
 
 struct SelectedDatePhysicalConditionGraph: View {
     let targetDate: Date
+    @EnvironmentObject var router: ConditionScreenNavigationRouter
 
     var body: some View {
         GeometryReader { geometry in
-            VStack {
+            VStack(spacing: 40) {
                 Text("\(targetDate.toString(format: "yyyy/MM/dd"))")
                     .font(.title3)
                 NavigationLink(value: ConditionScreenNavigationItem.dailyPhysicalConditionList(date: targetDate)) {
                     PhysicalConditionGraph(targetDate: targetDate)
                         .frame(width: geometry.size.width * 4 / 5, height: geometry.size.height / 2)
                 }
+                CommonButtonView(title: "新規登録") {
+                    router.items.append(.physicalConditionEntryForm(date: targetDate))
+                }
             }
             .frame(maxWidth: .infinity)
         }
     }
 }
-
-// #Preview {
-//    SelectedDatePhysicalConditionGraph()
-// }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/ActivityEntryAreaViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/ActivityEntryAreaViewModel.swift
@@ -10,18 +10,29 @@ import SwiftUI
 
 class ActivityEntryAreaViewModel: ObservableObject {
     @Published var isExpanded = false
-    let topActivityNavigationLinks = [
-        (destination: ConditionScreenNavigationItem.physicalConditionEntryForm(date: Date()),
-         imageName: ConditionNavigationLink.ImageName.physicalConditionEntryForm),
-        (destination: ConditionScreenNavigationItem.reviewEntryForm,
-         imageName: ConditionNavigationLink.ImageName.reviewEntryForm)
-    ]
-    let leftActivityNavigationLinks = [
-        (destination: ConditionScreenNavigationItem.stepEntryForm,
-         imageName: ConditionNavigationLink.ImageName.stepEntryForm),
-        (destination: ConditionScreenNavigationItem.hydrationEntryForm(date: Date()),
-         imageName: ConditionNavigationLink.ImageName.hydrationEntryForm)
-    ]
+    let targetDate: Date
+
+    init(targetDate: Date) {
+        self.targetDate = targetDate
+    }
+
+    var topActivityNavigationLinks: [(destination: ConditionScreenNavigationItem, imageName: ConditionNavigationLink.ImageName)] {
+        [
+            (destination: ConditionScreenNavigationItem.physicalConditionEntryForm(date: targetDate),
+             imageName: ConditionNavigationLink.ImageName.physicalConditionEntryForm),
+            (destination: ConditionScreenNavigationItem.reviewEntryForm,
+             imageName: ConditionNavigationLink.ImageName.reviewEntryForm)
+        ]
+    }
+
+    var leftActivityNavigationLinks: [(destination: ConditionScreenNavigationItem, imageName: ConditionNavigationLink.ImageName)] {
+        [
+            (destination: ConditionScreenNavigationItem.stepEntryForm,
+             imageName: ConditionNavigationLink.ImageName.stepEntryForm),
+            (destination: ConditionScreenNavigationItem.hydrationEntryForm(date: targetDate),
+             imageName: ConditionNavigationLink.ImageName.hydrationEntryForm)
+        ]
+    }
 
     func toggleExpanded() {
         withAnimation(Animation.linear(duration: 0.5)) {

--- a/RemoteWellnessSupportApp/Condition/ViewModels/ActivityEntryAreaViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/ActivityEntryAreaViewModel.swift
@@ -10,9 +10,8 @@ import SwiftUI
 
 class ActivityEntryAreaViewModel: ObservableObject {
     @Published var isExpanded = false
-
     let topActivityNavigationLinks = [
-        (destination: ConditionScreenNavigationItem.physicalConditionEntryForm,
+        (destination: ConditionScreenNavigationItem.physicalConditionEntryForm(date: Date()),
          imageName: ConditionNavigationLink.ImageName.physicalConditionEntryForm),
         (destination: ConditionScreenNavigationItem.reviewEntryForm,
          imageName: ConditionNavigationLink.ImageName.reviewEntryForm)
@@ -20,7 +19,7 @@ class ActivityEntryAreaViewModel: ObservableObject {
     let leftActivityNavigationLinks = [
         (destination: ConditionScreenNavigationItem.stepEntryForm,
          imageName: ConditionNavigationLink.ImageName.stepEntryForm),
-        (destination: ConditionScreenNavigationItem.hydrationEntryForm,
+        (destination: ConditionScreenNavigationItem.hydrationEntryForm(date: Date()),
          imageName: ConditionNavigationLink.ImageName.hydrationEntryForm)
     ]
 

--- a/RemoteWellnessSupportApp/Condition/ViewModels/ConditionScreenNavigationRouter.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/ConditionScreenNavigationRouter.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum ConditionScreenNavigationItem: Hashable {
-    case physicalConditionEntryForm
+    case physicalConditionEntryForm(date: Date)
     case reviewEntryForm
     case stepEntryForm
-    case hydrationEntryForm
+    case hydrationEntryForm(date: Date)
     case dailyPhysicalConditionList(date: Date)
     case weekPhysicalConditionList
     case weekHydrationList

--- a/RemoteWellnessSupportApp/Condition/Views/Children/ActivityEntryArea.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/ActivityEntryArea.swift
@@ -8,8 +8,14 @@
 import SwiftUI
 
 struct ActivityEntryArea: View {
-    @ObservedObject var viewModel = ActivityEntryAreaViewModel()
+    @ObservedObject var viewModel: ActivityEntryAreaViewModel
+    let targetDate: Date
     let spacing: CGFloat = 3
+
+    init(targetDate: Date = Date()) {
+        self.targetDate = targetDate
+        _viewModel = ObservedObject(wrappedValue: ActivityEntryAreaViewModel(targetDate: targetDate))
+    }
 
     var body: some View {
         VStack {

--- a/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
@@ -36,7 +36,7 @@ struct TodayCondition: View {
             }
             .onChange(of: notificationIdentifier) {
                 if notificationIdentifier != nil {
-                    router.items.append(.physicalConditionEntryForm)
+                    router.items.append(.physicalConditionEntryForm(date: today))
                 }
             }
         }

--- a/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
@@ -32,7 +32,7 @@ struct TodayCondition: View {
                         }
                     }
                 }
-                ActivityEntryArea()
+                ActivityEntryArea(targetDate: today)
             }
             .onChange(of: notificationIdentifier) {
                 if notificationIdentifier != nil {

--- a/RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
@@ -55,14 +55,14 @@ struct ConditionScreen: View {
             PhysicalConditionEditForm(physicalCondition: physicalCondition)
         case let .hydrationEditForm(hydration):
             HydrationEditForm(hydration: hydration)
-        case .physicalConditionEntryForm:
-            PhysicalConditionCreateForm()
+        case let .physicalConditionEntryForm(date):
+            PhysicalConditionCreateForm(targetDate: date)
         case .reviewEntryForm:
             ReviewEntryForm()
         case .stepEntryForm:
             StepEntryForm()
-        case .hydrationEntryForm:
-            HydrationCreateForm()
+        case let .hydrationEntryForm(date):
+            HydrationCreateForm(targetDate: date)
         case let .selectedDatePhysicalConditionGraph(targetDate):
             SelectedDatePhysicalConditionGraph(targetDate: targetDate)
         case let .selectedDateHydrationGraph(targetDate):


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- 日付を指定して体調登録と水分登録ができるように、各ビューモデルとビューに機能を追加。
- 新規登録ボタンを日付指定のグラフビューに追加し、指定日での登録画面に遷移する機能を実装。
- ナビゲーションリンクとルーターを更新し、日付指定での登録遷移をサポート。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>HydrationEntryFormViewModel.swift</strong><dd><code>水分登録フォームに日付指定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/Hydration/ViewModels/HydrationEntryFormViewModel.swift
<li><code>targetDate</code> プロパティを追加し、初期化時に設定可能にした。<br> <li> 新規登録時に <code>targetDate</code> をフォームの初期値として設定するように変更。<br>


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-e35dd96ec5991fcc31870db46b1ed8d0cea6a48bbf9d7ef3d4dc74ce0ef0d783">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HydrationCreateForm.swift</strong><dd><code>水分登録ビューに日付指定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/Hydration/Views/HydrationCreateForm.swift
- `targetDate` パラメータを持つコンストラクタを追加。
- プレビュー部分を削除。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-2ece458db9178c7db33a301bb4f05db7664bd91d7cc0a1d1223eb5bbe5e159fd">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SelectedDateHydrationGraph.swift</strong><dd><code>日付指定の水分グラフビューに新規登録ボタンを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/Hydration/Views/SelectedDateHydrationGraph.swift
- 新規登録ボタンを追加し、押下時に指定日付での登録画面に遷移するようにした。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-2a313980e48f3ddc0f02ba56f3ac7e3a4e3b1c4f8b57019d0e69e89a82b11547">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PhysicalConditionEntryFormViewModel.swift</strong><dd><code>体調登録フォームに日付指定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/ViewModels/PhysicalConditionEntryFormViewModel.swift
<li><code>targetDate</code> プロパティを追加し、初期化時に設定可能にした。<br> <li> 新規登録時に <code>targetDate</code> をフォームの初期値として設定するように変更。<br>


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-2a1243638fdba2536cfdea1af93f7876d2addcc8d29b07aa9261590bbaee39e0">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PhysicalConditionCreateForm.swift</strong><dd><code>体調登録ビューに日付指定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/PhysicalConditionCreateForm.swift
- `targetDate` パラメータを持つコンストラクタを追加。
- プレビュー部分を削除。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-b6548d7d51a224811121acf377ada360d2e98ff92a31a42e2296271f7a049984">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SelectedDatePhysicalConditionGraph.swift</strong><dd><code>日付指定の体調グラフビューに新規登録ボタンを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Activity/PhysicalCondition/Views/SelectedDatePhysicalConditionGraph.swift
- 新規登録ボタンを追加し、押下時に指定日付での登録画面に遷移するようにした。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-72325ab28537dc50bde65152c5c7408bf2c34b153c99c25fd1dda70b9a4f266c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ActivityEntryAreaViewModel.swift</strong><dd><code>アクティビティエントリーエリアのナビゲーションリンクを更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/ActivityEntryAreaViewModel.swift
- 日付を指定して体調登録と水分登録を行えるようにナビゲーションリンクを更新。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-aa6091326af22dd57956dd7da29b4e10d5fa52bd9c4cd98f0fa8ee700c49ff90">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ConditionScreenNavigationRouter.swift</strong><dd><code>ナビゲーションルーターに日付指定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/ConditionScreenNavigationRouter.swift
- 体調登録と水分登録のナビゲーションアイテムに日付を指定する機能を追加。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-f4bedb3686d14439f4944a7cf8f35fc693640f4eae79ac25b3c069a941b18620">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TodayCondition.swift</strong><dd><code>今日の条件ビューでの体調登録遷移を更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/Children/TodayCondition.swift
- 通知を受け取った際に今日の日付で体調登録画面に遷移するように変更。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-c321ea6ac17951e8ab53f506954458cb841093ef0368706c411711dad043e164">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ConditionScreen.swift</strong><dd><code>条件画面での体調・水分登録ビューの遷移を更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/ConditionScreen.swift
- 体調登録と水分登録のビューを日付指定で開けるように変更。



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/17/files#diff-df47fcea3c054f11d859d339b73b9e5970fe3aed2da8ba3acfd0c9ff3916333f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - ユーザーが特定の日付をターゲットにして水分摂取と体調のデータを入力できるようになりました。
    - 体調画面に「新規登録」ボタンを追加し、タップすると特定の日付でのデータ入力画面に遷移します。

- **バグ修正**
    - 体調と水分摂取のフォームの初期値が、指定された日付に基づいて正しく設定されるようになりました。

- **リファクタ**
    - 特定の日付を扱うためのコードが複数の場所で更新され、より直感的に日付を管理できるようになりました。

- **スタイルの改善**
    - 体調登録画面のレイアウトにスペースを追加し、視認性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->