### PR TITLE
Feature/tas 29 pomodoro reminder notifications

### DIFF
--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2E041C232BDCF6940082CBD6 /* BreakTimeProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E041C222BDCF6940082CBD6 /* BreakTimeProgressView.swift */; };
 		2E041C252BDCF6A10082CBD6 /* BreakTimeProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E041C242BDCF6A10082CBD6 /* BreakTimeProgressViewModel.swift */; };
 		2E09E7C82BCD4982004DC601 /* CircleProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09E7C72BCD4982004DC601 /* CircleProgress.swift */; };
+		2E0A11EF2BF6BEA9001CE56F /* PomodoroTimerViewModel+FetchReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0A11EE2BF6BEA9001CE56F /* PomodoroTimerViewModel+FetchReminder.swift */; };
+		2E0A11F12C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0A11F02C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift */; };
 		2E0ACDF32B93E42200318BF2 /* DailyPhysicalConditionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF22B93E42200318BF2 /* DailyPhysicalConditionList.swift */; };
 		2E0ACDF52B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF42B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift */; };
 		2E0ACDF82B947CD800318BF2 /* ActivityEditDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0ACDF72B947CD800318BF2 /* ActivityEditDestination.swift */; };
@@ -92,6 +94,16 @@
 		2E868ABA2BB6372500681E6B /* SelectedDateHydrationGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E868AB92BB6372500681E6B /* SelectedDateHydrationGraph.swift */; };
 		2E8C66D12B81DF2300280A17 /* PhysicalCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8C66D02B81DF2300280A17 /* PhysicalCondition.swift */; };
 		2E8C66DB2B856F9100280A17 /* StyledTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8C66DA2B856F9100280A17 /* StyledTextEditor.swift */; };
+		2E8E60D42BF2D050005B1232 /* PomodoroReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60D32BF2D050005B1232 /* PomodoroReminder.swift */; };
+		2E8E60D62BF2D0B9005B1232 /* PomodoroReminderDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60D52BF2D0B9005B1232 /* PomodoroReminderDataSource.swift */; };
+		2E8E60D82BF2D165005B1232 /* PomodoroReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60D72BF2D165005B1232 /* PomodoroReminderView.swift */; };
+		2E8E60DA2BF420AB005B1232 /* PomodoroReminderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60D92BF420AB005B1232 /* PomodoroReminderViewModel.swift */; };
+		2E8E60DC2BF4221A005B1232 /* BasePomodoroReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60DB2BF4221A005B1232 /* BasePomodoroReminder.swift */; };
+		2E8E60DF2BF57B82005B1232 /* PomodoroTimerViewModel+MainTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60DE2BF57B82005B1232 /* PomodoroTimerViewModel+MainTimer.swift */; };
+		2E8E60E12BF57C03005B1232 /* PomodoroTimerViewModel+BreakTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60E02BF57C03005B1232 /* PomodoroTimerViewModel+BreakTimer.swift */; };
+		2E8E60E32BF57C82005B1232 /* PomodoroTimerViewModel+StopTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60E22BF57C82005B1232 /* PomodoroTimerViewModel+StopTimer.swift */; };
+		2E8E60E52BF57CF1005B1232 /* PomodoroTimerViewModel+FetchTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60E42BF57CF1005B1232 /* PomodoroTimerViewModel+FetchTimer.swift */; };
+		2E8E60E72BF57D99005B1232 /* PomodoroTimerViewModel+Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8E60E62BF57D99005B1232 /* PomodoroTimerViewModel+Notification.swift */; };
 		2E8FBEC32BA520BA0082B3E1 /* ConditionScreenNavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8FBEC22BA520BA0082B3E1 /* ConditionScreenNavigationRouter.swift */; };
 		2E8FBEC62BA676C60082B3E1 /* NotificationSettingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8FBEC52BA676C60082B3E1 /* NotificationSettingScreen.swift */; };
 		2E8FBEC82BA679D20082B3E1 /* NotificationSettingNavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8FBEC72BA679D20082B3E1 /* NotificationSettingNavigationRouter.swift */; };
@@ -258,6 +270,8 @@
 		2E041C222BDCF6940082CBD6 /* BreakTimeProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakTimeProgressView.swift; sourceTree = "<group>"; };
 		2E041C242BDCF6A10082CBD6 /* BreakTimeProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakTimeProgressViewModel.swift; sourceTree = "<group>"; };
 		2E09E7C72BCD4982004DC601 /* CircleProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProgress.swift; sourceTree = "<group>"; };
+		2E0A11EE2BF6BEA9001CE56F /* PomodoroTimerViewModel+FetchReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+FetchReminder.swift"; sourceTree = "<group>"; };
+		2E0A11F02C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+CommonProcessTimer.swift"; sourceTree = "<group>"; };
 		2E0ACDF22B93E42200318BF2 /* DailyPhysicalConditionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPhysicalConditionList.swift; sourceTree = "<group>"; };
 		2E0ACDF42B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPhysicalConditionListViewModel.swift; sourceTree = "<group>"; };
 		2E0ACDF72B947CD800318BF2 /* ActivityEditDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEditDestination.swift; sourceTree = "<group>"; };
@@ -336,6 +350,16 @@
 		2E868AB92BB6372500681E6B /* SelectedDateHydrationGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedDateHydrationGraph.swift; sourceTree = "<group>"; };
 		2E8C66D02B81DF2300280A17 /* PhysicalCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalCondition.swift; sourceTree = "<group>"; };
 		2E8C66DA2B856F9100280A17 /* StyledTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledTextEditor.swift; sourceTree = "<group>"; };
+		2E8E60D32BF2D050005B1232 /* PomodoroReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminder.swift; sourceTree = "<group>"; };
+		2E8E60D52BF2D0B9005B1232 /* PomodoroReminderDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminderDataSource.swift; sourceTree = "<group>"; };
+		2E8E60D72BF2D165005B1232 /* PomodoroReminderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminderView.swift; sourceTree = "<group>"; };
+		2E8E60D92BF420AB005B1232 /* PomodoroReminderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminderViewModel.swift; sourceTree = "<group>"; };
+		2E8E60DB2BF4221A005B1232 /* BasePomodoroReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePomodoroReminder.swift; sourceTree = "<group>"; };
+		2E8E60DE2BF57B82005B1232 /* PomodoroTimerViewModel+MainTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+MainTimer.swift"; sourceTree = "<group>"; };
+		2E8E60E02BF57C03005B1232 /* PomodoroTimerViewModel+BreakTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+BreakTimer.swift"; sourceTree = "<group>"; };
+		2E8E60E22BF57C82005B1232 /* PomodoroTimerViewModel+StopTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+StopTimer.swift"; sourceTree = "<group>"; };
+		2E8E60E42BF57CF1005B1232 /* PomodoroTimerViewModel+FetchTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+FetchTimer.swift"; sourceTree = "<group>"; };
+		2E8E60E62BF57D99005B1232 /* PomodoroTimerViewModel+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PomodoroTimerViewModel+Notification.swift"; sourceTree = "<group>"; };
 		2E8FBEC22BA520BA0082B3E1 /* ConditionScreenNavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionScreenNavigationRouter.swift; sourceTree = "<group>"; };
 		2E8FBEC52BA676C60082B3E1 /* NotificationSettingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingScreen.swift; sourceTree = "<group>"; };
 		2E8FBEC72BA679D20082B3E1 /* NotificationSettingNavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingNavigationRouter.swift; sourceTree = "<group>"; };
@@ -714,6 +738,7 @@
 				2E61D0AC2BB238C00087B895 /* Hydration.swift */,
 				2E7EC78A2BD09CB400EF4854 /* Pomodoro.swift */,
 				2E9D61B42BED8B5200C8F062 /* HydrationReminder.swift */,
+				2E8E60D32BF2D050005B1232 /* PomodoroReminder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -752,6 +777,7 @@
 				2EFD1B9F2BE993DF0014EDBE /* PhysicalConditionReminderEditViewModel.swift */,
 				2E9D61DB2BEEEF8E00C8F062 /* HydrationReminderViewModel.swift */,
 				2EA2C59E2BF05BD500F7751D /* HydrationReminderEditViewModel.swift */,
+				2E8E60D92BF420AB005B1232 /* PomodoroReminderViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -785,6 +811,20 @@
 			path = ViewModifiers;
 			sourceTree = "<group>";
 		};
+		2E8E60DD2BF57B3C005B1232 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				2E8E60DE2BF57B82005B1232 /* PomodoroTimerViewModel+MainTimer.swift */,
+				2E8E60E02BF57C03005B1232 /* PomodoroTimerViewModel+BreakTimer.swift */,
+				2E8E60E22BF57C82005B1232 /* PomodoroTimerViewModel+StopTimer.swift */,
+				2E8E60E42BF57CF1005B1232 /* PomodoroTimerViewModel+FetchTimer.swift */,
+				2E8E60E62BF57D99005B1232 /* PomodoroTimerViewModel+Notification.swift */,
+				2E0A11EE2BF6BEA9001CE56F /* PomodoroTimerViewModel+FetchReminder.swift */,
+				2E0A11F02C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		2E8FBEC92BA67BDA0082B3E1 /* Children */ = {
 			isa = PBXGroup;
 			children = (
@@ -793,6 +833,7 @@
 				2E8FBECA2BA67BF20082B3E1 /* NotificationSettingEndView.swift */,
 				2E8FBECC2BA67D680082B3E1 /* PhysicalConditionReminderView.swift */,
 				2E9D61D92BEEEEC700C8F062 /* HydrationReminderView.swift */,
+				2E8E60D72BF2D165005B1232 /* PomodoroReminderView.swift */,
 			);
 			path = Children;
 			sourceTree = "<group>";
@@ -1120,6 +1161,7 @@
 				2E61D0AE2BB2396A0087B895 /* HydrationDataSource.swift */,
 				2E99F0352BD14C4600F7E97F /* PomodoroDataSource.swift */,
 				2E9D61E32BEEFB5D00C8F062 /* HydrationReminderDataSource.swift */,
+				2E8E60D52BF2D0B9005B1232 /* PomodoroReminderDataSource.swift */,
 			);
 			path = DataSources;
 			sourceTree = "<group>";
@@ -1312,6 +1354,7 @@
 		2EE812EA2B7A2427000B65E5 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				2E8E60DD2BF57B3C005B1232 /* Extensions */,
 				2EE812EB2B7A243C000B65E5 /* ActivityEntryAreaViewModel.swift */,
 				2E6983682B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift */,
 				2E8FBEC22BA520BA0082B3E1 /* ConditionScreenNavigationRouter.swift */,
@@ -1365,6 +1408,7 @@
 				2EFD1BA22BE9A2E10014EDBE /* BasePhysicalConditionReminder.swift */,
 				2E9D61DF2BEEF5DC00C8F062 /* BaseReminderScheduler.swift */,
 				2E9D61E12BEEF98F00C8F062 /* BaseHydrationReminder.swift */,
+				2E8E60DB2BF4221A005B1232 /* BasePomodoroReminder.swift */,
 			);
 			path = Commons;
 			sourceTree = "<group>";
@@ -1475,11 +1519,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				2E61D0AB2BB238130087B895 /* HydrationEntryFormViewModel.swift in Sources */,
+				2E8E60D42BF2D050005B1232 /* PomodoroReminder.swift in Sources */,
 				2E6FE2122BA2750100541819 /* AppDelegate.swift in Sources */,
+				2E8E60E52BF57CF1005B1232 /* PomodoroTimerViewModel+FetchTimer.swift in Sources */,
 				2E8C66D12B81DF2300280A17 /* PhysicalCondition.swift in Sources */,
 				2E916C6C2BDF62690016D67E /* SettingListViewModel.swift in Sources */,
 				2EE812EC2B7A243C000B65E5 /* ActivityEntryAreaViewModel.swift in Sources */,
 				2E9D61E62BEF102F00C8F062 /* ReminderType.swift in Sources */,
+				2E0A11EF2BF6BEA9001CE56F /* PomodoroTimerViewModel+FetchReminder.swift in Sources */,
 				2E61D0BF2BB432520087B895 /* DailyHydrationList.swift in Sources */,
 				2E642DDA2BEC47C60075BC7E /* CustomSection.swift in Sources */,
 				2EB206A12BC805D5003F0700 /* WeekStepGraphViewModel.swift in Sources */,
@@ -1495,12 +1542,14 @@
 				2E0DA42A2B8E113D004E0185 /* PhysicalConditionChartYModifier.swift in Sources */,
 				2E8FBEF62BAA8A310082B3E1 /* ModelManager.swift in Sources */,
 				2E99F0362BD14C4600F7E97F /* PomodoroDataSource.swift in Sources */,
+				2E8E60DF2BF57B82005B1232 /* PomodoroTimerViewModel+MainTimer.swift in Sources */,
 				2E8FBECD2BA67D680082B3E1 /* PhysicalConditionReminderView.swift in Sources */,
 				2E8FBEE72BA86F630082B3E1 /* TimePicker.swift in Sources */,
 				2E61D0B72BB2F26E0087B895 /* HydrationGraph.swift in Sources */,
 				2E6E640E2B7E37A300A11DB9 /* PhysicalConditionRating.swift in Sources */,
 				2E61D0B52BB246B80087B895 /* HydrationCreateForm.swift in Sources */,
 				2E0C95DA2B6BC62D00576531 /* CommonButtonView.swift in Sources */,
+				2E8E60D62BF2D0B9005B1232 /* PomodoroReminderDataSource.swift in Sources */,
 				2E57473D2BC55E7D00B46C55 /* StepGraphViewModel.swift in Sources */,
 				2E0C95CC2B6A7D2F00576531 /* HealthReviewDescriptionView.swift in Sources */,
 				2E782F9C2BDDD598008B00F7 /* Notification+Extensions.swift in Sources */,
@@ -1514,12 +1563,14 @@
 				2EBA3DAE2BCBB99300599131 /* PomodoroTimer.swift in Sources */,
 				2E8FBED32BA6E6AA0082B3E1 /* PhysicalConditionReminder.swift in Sources */,
 				2E642DDD2BECFB070075BC7E /* ReminderViewModelProtocol.swift in Sources */,
+				2E8E60E72BF57D99005B1232 /* PomodoroTimerViewModel+Notification.swift in Sources */,
 				2E0ACDF52B93E9EA00318BF2 /* DailyPhysicalConditionListViewModel.swift in Sources */,
 				2E6FE20C2BA26D2700541819 /* NotificationPermissionView.swift in Sources */,
 				2E1194A32BE4773A00DB4BD3 /* WorkTimeEditInputView.swift in Sources */,
 				2E7EC78B2BD09CB400EF4854 /* Pomodoro.swift in Sources */,
 				2EB9421D2BB01F6400F3B0D2 /* TextInput.swift in Sources */,
 				2E6983652B9C728D0076EF4F /* WeekCondition.swift in Sources */,
+				2E8E60E12BF57C03005B1232 /* PomodoroTimerViewModel+BreakTimer.swift in Sources */,
 				2ED5FF142BE6596D0025113D /* RestTimePeriodSection+Extensions.swift in Sources */,
 				2E041C1F2BDCD8B00082CBD6 /* StepProgressView.swift in Sources */,
 				2E9D61DA2BEEEEC700C8F062 /* HydrationReminderView.swift in Sources */,
@@ -1535,6 +1586,7 @@
 				2EE812DB2B79904E000B65E5 /* ReviewEntryForm.swift in Sources */,
 				2E0C95CE2B6A7E8000576531 /* WatchFeatureExplanationView.swift in Sources */,
 				2E99F03F2BD3267500F7E97F /* WeekPomodoroGraph.swift in Sources */,
+				2E8E60DA2BF420AB005B1232 /* PomodoroReminderViewModel.swift in Sources */,
 				2E61D0BB2BB2F8D20087B895 /* GraphValueChartView.swift in Sources */,
 				2E6E64112B7EDEE900A11DB9 /* StyleConst.swift in Sources */,
 				2E8FBED12BA680FC0082B3E1 /* NotificationSettingEndViewModel.swift in Sources */,
@@ -1556,6 +1608,7 @@
 				2E712E2E2BE1ACFE004F574D /* NicknameEditInputView.swift in Sources */,
 				2EA2C5992BF0454F00F7751D /* ReminderNotificationData.swift in Sources */,
 				2ED5FF0F2BE64F820025113D /* GoalSettingEditInputViewModel.swift in Sources */,
+				2E0A11F12C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift in Sources */,
 				2E041C212BDCD8DA0082CBD6 /* StepProgressViewModel.swift in Sources */,
 				2E6983692B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift in Sources */,
 				2E61D0BD2BB302190087B895 /* HydrationChartYModifier.swift in Sources */,
@@ -1614,6 +1667,7 @@
 				2E916C5E2BDF295A0016D67E /* SettingScreen.swift in Sources */,
 				2E947A6F2BD87C07002B660A /* GoalProgressView.swift in Sources */,
 				2E868ABA2BB6372500681E6B /* SelectedDateHydrationGraph.swift in Sources */,
+				2E8E60D82BF2D165005B1232 /* PomodoroReminderView.swift in Sources */,
 				2EE812C12B790137000B65E5 /* MainView.swift in Sources */,
 				2EB942052BAEBF2500F3B0D2 /* WorkTimeInputView.swift in Sources */,
 				2EB942242BB0500B00F3B0D2 /* TitleView.swift in Sources */,
@@ -1635,6 +1689,7 @@
 				2EB942122BAFB8A000F3B0D2 /* RestTimePeriodSection.swift in Sources */,
 				2E0C95D32B6B0D2B00576531 /* OnBoardingTab.swift in Sources */,
 				2E61D0AD2BB238C00087B895 /* Hydration.swift in Sources */,
+				2E8E60E32BF57C82005B1232 /* PomodoroTimerViewModel+StopTimer.swift in Sources */,
 				2EE812E72B79A6F0000B65E5 /* ActivityEntryNavigationLink.swift in Sources */,
 				2E9D61E22BEEF98F00C8F062 /* BaseHydrationReminder.swift in Sources */,
 				2EB4D52E2BE6FE3C00FF4A2A /* ReminderSettingViewModel.swift in Sources */,
@@ -1667,6 +1722,7 @@
 				2EB942272BB0512200F3B0D2 /* CommonPaddingModifier.swift in Sources */,
 				2E868AB62BB6332700681E6B /* WeekHydrationListView.swift in Sources */,
 				2EBA3DA52BCB7BF200599131 /* WeekStepListView.swift in Sources */,
+				2E8E60DC2BF4221A005B1232 /* BasePomodoroReminder.swift in Sources */,
 				2EBA3DA72BCB7C0F00599131 /* WeekStepListViewModel.swift in Sources */,
 				2EFD1BA02BE993DF0014EDBE /* PhysicalConditionReminderEditViewModel.swift in Sources */,
 				2E0DA4232B8CBD9C004E0185 /* TimeZoneType.swift in Sources */,

--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		2E1194A52BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A42BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift */; };
 		2E1194A72BE5BBFD00DB4BD3 /* RestTimeEditInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A62BE5BBFD00DB4BD3 /* RestTimeEditInputView.swift */; };
 		2E1194A92BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A82BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift */; };
+		2E16966E2C03F6B900D540BD /* PomodoroReminderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E16966D2C03F6B900D540BD /* PomodoroReminderType.swift */; };
 		2E17831F2BE0537200F07B97 /* ProfileSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E17831E2BE0537200F07B97 /* ProfileSettingViewModel.swift */; };
 		2E50E67E2BE2FC2F00068916 /* NicknameEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E67D2BE2FC2F00068916 /* NicknameEditInputViewModel.swift */; };
 		2E50E6802BE305EC00068916 /* WorkDaySelectEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E67F2BE305EC00068916 /* WorkDaySelectEditView.swift */; };
@@ -300,6 +301,7 @@
 		2E1194A42BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkTimeEditInputViewModel.swift; sourceTree = "<group>"; };
 		2E1194A62BE5BBFD00DB4BD3 /* RestTimeEditInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimeEditInputView.swift; sourceTree = "<group>"; };
 		2E1194A82BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimeEditInputViewModel.swift; sourceTree = "<group>"; };
+		2E16966D2C03F6B900D540BD /* PomodoroReminderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminderType.swift; sourceTree = "<group>"; };
 		2E17831E2BE0537200F07B97 /* ProfileSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewModel.swift; sourceTree = "<group>"; };
 		2E50E67D2BE2FC2F00068916 /* NicknameEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditInputViewModel.swift; sourceTree = "<group>"; };
 		2E50E67F2BE305EC00068916 /* WorkDaySelectEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkDaySelectEditView.swift; sourceTree = "<group>"; };
@@ -1347,6 +1349,7 @@
 				2EE812E42B79A4A0000B65E5 /* ConditionNavigationLink.swift */,
 				2E0DA4222B8CBD9C004E0185 /* TimeZoneType.swift */,
 				2E0DA4242B8D5DC4004E0185 /* GraphDefinition.swift */,
+				2E16966D2C03F6B900D540BD /* PomodoroReminderType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1554,6 +1557,7 @@
 				2E0C95CC2B6A7D2F00576531 /* HealthReviewDescriptionView.swift in Sources */,
 				2E782F9C2BDDD598008B00F7 /* Notification+Extensions.swift in Sources */,
 				2E631C6E2B896F0D00B35AAC /* PhysicalConditionGraph.swift in Sources */,
+				2E16966E2C03F6B900D540BD /* PomodoroReminderType.swift in Sources */,
 				2E0DA4282B8E10EB004E0185 /* ChartXAxisModifier.swift in Sources */,
 				2E8FBEF22BAA7A850082B3E1 /* Reminder+Extensions.swift in Sources */,
 				2E8FBEC32BA520BA0082B3E1 /* ConditionScreenNavigationRouter.swift in Sources */,

--- a/RemoteWellnessSupportApp/Common/DataSources/PomodoroReminderDataSource.swift
+++ b/RemoteWellnessSupportApp/Common/DataSources/PomodoroReminderDataSource.swift
@@ -1,0 +1,34 @@
+//
+//  PomodoroReminderDataSource.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/14.
+//
+
+import Foundation
+import SwiftData
+
+final class PomodoroReminderDataSource {
+    private let manager = ModelManager.shared
+    private let modelContainer: ModelContainer
+    private let modelContext: ModelContext
+
+    @MainActor
+    static let shared = PomodoroReminderDataSource()
+
+    @MainActor
+    private init() {
+        modelContainer = manager.modelContainer
+        modelContext = manager.modelContext
+    }
+
+    func insertPomodoroReminder(pomodoroReminder: PomodoroReminder) throws {
+        modelContext.insert(pomodoroReminder)
+        try modelContext.save()
+    }
+
+    func fetchPomodoroReminder() throws -> PomodoroReminder? {
+        let descriptor = FetchDescriptor<PomodoroReminder>()
+        return try modelContext.fetch(descriptor).first ?? nil
+    }
+}

--- a/RemoteWellnessSupportApp/Common/Models/PomodoroReminder.swift
+++ b/RemoteWellnessSupportApp/Common/Models/PomodoroReminder.swift
@@ -1,0 +1,24 @@
+//
+//  PomodoroReminder.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/14.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class PomodoroReminder {
+    @Attribute(.unique) var id: String = UUID().uuidString
+    var isActive: Bool
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(id: String = UUID().uuidString, isActive: Bool, createdAt: Date = Date(), updatedAt: Date = Date()) {
+        self.id = id
+        self.isActive = isActive
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/Enums/PomodoroReminderType.swift
+++ b/RemoteWellnessSupportApp/Condition/Enums/PomodoroReminderType.swift
@@ -1,0 +1,17 @@
+//
+//  PomodoroReminderType.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/27.
+//
+
+import Foundation
+
+enum PomodoroReminderType: String {
+    case mainTimer
+    case breakTimer
+
+    static func fromIdentifier(_ identifier: String) -> PomodoroReminderType? {
+        PomodoroReminderType(rawValue: identifier)
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+BreakTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+BreakTimer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension PomodoroTimerViewModel {
-    func startBraekMode() {
+    func startBreakMode() {
         timer?.cancel()
         secondsLeft = PomodoroTimerViewModel.BreakTime
         currentMaxTime = PomodoroTimerViewModel.BreakTime
@@ -21,7 +21,8 @@ extension PomodoroTimerViewModel {
 
     func endBreakTimer() {
         guard let pomodoroGroupId else {
-            fatalError("不正な値です")
+            setError(withMessage: "不正な値です")
+            return
         }
         let pomodoro = Pomodoro(pomodoroGroupId: pomodoroGroupId.uuidString, activityType: .breakTime)
 

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+BreakTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+BreakTimer.swift
@@ -1,0 +1,43 @@
+//
+//  PomodoroTimerViewModel+BreakTimer.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/16.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func startBraekMode() {
+        timer.invalidate()
+        secondsLeft = PomodoroTimerViewModel.BreakTime
+        currentMaxTime = PomodoroTimerViewModel.BreakTime
+        timerMode = .breakMode
+        Task {
+            await sendBreakTimerEndNotification()
+        }
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            if secondsLeft == 0 {
+                endBreakTimer()
+            } else {
+                secondsLeft -= 1
+            }
+        }
+    }
+
+    func endBreakTimer() {
+        guard let pomodoroGroupId else {
+            fatalError("不正な値です")
+        }
+        let pomodoro = Pomodoro(pomodoroGroupId: pomodoroGroupId.uuidString, activityType: .breakTime)
+
+        do {
+            try dataSource.insertPomodoro(pomodoro: pomodoro)
+            NotificationCenter.default.post(name: .didUpdatePomodoroData, object: nil)
+        } catch {
+            setError(withMessage: "登録処理に失敗しました", error: error)
+        }
+        resetTimer()
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
@@ -1,0 +1,34 @@
+//
+//  PomodoroTimerViewModel+CommonProcessTimer.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/25.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func backgroundSetTimer() {
+        backgroundEntryTimestamp = Date()
+        remain = secondsLeft
+    }
+
+    func syncTimerOnActive() {
+        guard let backgroundEntry = backgroundEntryTimestamp else {
+            return
+        }
+
+        let backgroundDuration = Date().timeIntervalSince(backgroundEntry)
+        let remainingTime = Double(remain) - backgroundDuration
+
+        if remainingTime <= 0 {
+            if timerMode == .running {
+                endMainTimer()
+            } else if timerMode == .breakMode {
+                endBreakTimer()
+            }
+        } else {
+            secondsLeft = Int(remainingTime.rounded(.up))
+        }
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
@@ -33,7 +33,9 @@ extension PomodoroTimerViewModel {
     }
 
     func formatPomodoroTime(_ second: Int) -> String {
-        let formattedString = formatter.string(from: TimeInterval(second))!
+        guard let formattedString = formatter.string(from: TimeInterval(second)) else {
+            return ""
+        }
         return formattedString
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
@@ -28,7 +28,12 @@ extension PomodoroTimerViewModel {
                 endBreakTimer()
             }
         } else {
-            secondsLeft = Int(remainingTime.rounded(.up))
+            secondsLeft = Int(remainingTime.rounded(.toNearestOrAwayFromZero))
         }
+    }
+
+    func formatPomodoroTime(_ second: Int) -> String {
+        let formattedString = formatter.string(from: TimeInterval(second))!
+        return formattedString
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchReminder.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchReminder.swift
@@ -8,13 +8,8 @@
 import Foundation
 
 extension PomodoroTimerViewModel {
-    func fetchReminder() -> PomodoroReminder? {
-        do {
-            let reminder = try pomodoroReminderDataSource.fetchPomodoroReminder()
-            return reminder
-        } catch {
-            setError(withMessage: "取得処理に失敗しました", error: error)
-        }
-        return nil
+    func fetchReminder() throws -> PomodoroReminder? {
+        let reminder = try pomodoroReminderDataSource.fetchPomodoroReminder()
+        return reminder
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchReminder.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchReminder.swift
@@ -1,0 +1,20 @@
+//
+//  PomodoroTimerViewModel+FetchReminder.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/17.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func fetchReminder() -> PomodoroReminder? {
+        do {
+            let reminder = try pomodoroReminderDataSource.fetchPomodoroReminder()
+            return reminder
+        } catch {
+            setError(withMessage: "取得処理に失敗しました", error: error)
+        }
+        return nil
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchTimer.swift
@@ -1,0 +1,46 @@
+//
+//  PomodoroTimerViewModel+FetchTimer.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/16.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func fetchCount() -> [Pomodoro] {
+        do {
+            let predicate = try createPredicateForOneDayPomodoro()
+            let pomodoros = try dataSource.fetchPomodoros(predicate: predicate)
+            let workTimeEndPomodoros = pomodoros.filter {
+                $0.activityType == .workTime
+            }
+            return workTimeEndPomodoros
+        } catch {
+            setError(withMessage: "取得処理に失敗しました", error: error)
+        }
+        return []
+    }
+
+    private func createPredicateForOneDayPomodoro() throws -> Predicate<Pomodoro> {
+        let (startOfDay, endOfDay) = try dayPeriod(for: Date())
+        // let workTimeType = PomodoroActivityType.workTime
+        let predicate = #Predicate<Pomodoro> { pomodoro in
+
+            pomodoro.registeredAt >= startOfDay && pomodoro.registeredAt < endOfDay
+            // TODO: xcodeのバージョンを上げたら直るか確認
+            // pomodoro.activityType == workTimeType
+        }
+        return predicate
+    }
+
+    private func dayPeriod(for date: Date) throws -> (startOfDay: Date, endOfDay: Date) {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        let endOfDayComponents = DateComponents(day: 1)
+        guard let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay) else {
+            throw DateError.calculationFailed(description: "Failed to calculate the end of day")
+        }
+        return (startOfDay, endOfDay)
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchTimer.swift
@@ -8,18 +8,13 @@
 import Foundation
 
 extension PomodoroTimerViewModel {
-    func fetchCount() -> [Pomodoro] {
-        do {
-            let predicate = try createPredicateForOneDayPomodoro()
-            let pomodoros = try dataSource.fetchPomodoros(predicate: predicate)
-            let workTimeEndPomodoros = pomodoros.filter {
-                $0.activityType == .workTime
-            }
-            return workTimeEndPomodoros
-        } catch {
-            setError(withMessage: "取得処理に失敗しました", error: error)
+    func fetchCount() throws -> [Pomodoro] {
+        let predicate = try createPredicateForOneDayPomodoro()
+        let pomodoros = try dataSource.fetchPomodoros(predicate: predicate)
+        let workTimeEndPomodoros = pomodoros.filter {
+            $0.activityType == .workTime
         }
-        return []
+        return workTimeEndPomodoros
     }
 
     private func createPredicateForOneDayPomodoro() throws -> Predicate<Pomodoro> {

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+MainTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+MainTimer.swift
@@ -1,0 +1,55 @@
+//
+//  PomodoroTimerViewModel+MainTimer.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/16.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func startTimer() {
+        timer.invalidate()
+        secondsLeft = PomodoroTimerViewModel.MaxTimer
+        currentMaxTime = PomodoroTimerViewModel.MaxTimer
+        timerMode = .running
+        pomodoroGroupId = UUID()
+        timerStartTimestamp = Date()
+        Task {
+            await sendMainTimerEndNotification()
+        }
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            if secondsLeft == 0 {
+                if timerMode == .running {
+                    endMainTimer()
+                } else {
+                    resetTimer()
+                }
+            } else {
+                secondsLeft -= 1
+            }
+        }
+    }
+
+    func endMainTimer() {
+        timer.invalidate()
+        secondsLeft = PomodoroTimerViewModel.BreakTime
+        currentMaxTime = PomodoroTimerViewModel.BreakTime
+        timerMode = .initial
+        guard let pomodoroGroupId else {
+            setError(withMessage: "不正な値です")
+            return
+        }
+        let pomodoro = Pomodoro(pomodoroGroupId: pomodoroGroupId.uuidString, activityType: .workTime)
+        do {
+            try dataSource.insertPomodoro(pomodoro: pomodoro)
+
+            let workTimeEndPomodoros = fetchCount()
+            completedPomodoroCount = workTimeEndPomodoros.count
+        } catch {
+            setError(withMessage: "登録処理に失敗しました", error: error)
+        }
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+MainTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+MainTimer.swift
@@ -34,7 +34,7 @@ extension PomodoroTimerViewModel {
         do {
             try dataSource.insertPomodoro(pomodoro: pomodoro)
 
-            let workTimeEndPomodoros = fetchCount()
+            let workTimeEndPomodoros = try fetchCount()
             completedPomodoroCount = workTimeEndPomodoros.count
         } catch {
             setError(withMessage: "登録処理に失敗しました", error: error)

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+Notification.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+Notification.swift
@@ -1,0 +1,91 @@
+//
+//  PomodoroTimerViewModel+Notification.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/16.
+//
+
+import Foundation
+import UserNotifications
+
+extension PomodoroTimerViewModel {
+    func sendMainTimerEndNotification() async {
+        guard isReminderActive else {
+            return
+        }
+        await sendPomodoroNotification(type: .mainTimer, interval: 15)
+    }
+
+    func sendBreakTimerEndNotification() async {
+        guard isReminderActive else {
+            return
+        }
+        await sendPomodoroNotification(type: .breakTimer, interval: 3)
+    }
+
+    func cancelCurrentNotification(type: PomodoroReminderType) {
+        let reminderNotificationData = dataForPomodoroReminderType(type: type)
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: [reminderNotificationData.reminderName])
+    }
+
+    func resumeNotification() async {
+        let interval = secondsLeft
+        let type = timerMode == .breakMode ? PomodoroReminderType.breakTimer : PomodoroReminderType.mainTimer
+        await sendPomodoroNotification(type: type, interval: interval)
+    }
+
+    private func sendPomodoroNotification(type: PomodoroReminderType, interval: Int) async {
+        let reminderNotificationData = dataForPomodoroReminderType(type: type)
+        let center = UNUserNotificationCenter.current()
+        let checkStatus = await center.notificationSettings()
+        if checkStatus.authorizationStatus != .authorized {
+            return
+        }
+        // let requests = await center.pendingNotificationRequests()
+        center.removePendingNotificationRequests(withIdentifiers: [reminderNotificationData.reminderName])
+
+        let content = UNMutableNotificationContent()
+        content.title = reminderNotificationData.notificationTitle
+        content.body = reminderNotificationData.notificationBody
+        content.sound = UNNotificationSound.default
+
+        do {
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(interval), repeats: false)
+            let request = UNNotificationRequest(identifier: reminderNotificationData.reminderName, content: content, trigger: trigger)
+            try await center.add(request)
+        } catch {
+            setError(withMessage: "通知の許可リクエストまたは通知スケジュールに失敗しました")
+        }
+    }
+
+    private func dataForPomodoroReminderType(type: PomodoroReminderType) -> ReminderNotificationData {
+        var reminderName = ""
+        var notificationTitle = ""
+        var notificationBody = ""
+        switch type {
+        case .mainTimer:
+            reminderName = PomodoroReminderType.mainTimer.rawValue
+            // TODO: 分の数値を動的に変更
+            notificationTitle = "25分経ちました"
+            notificationBody = "休憩に入りましょう"
+        case .breakTimer:
+            reminderName = PomodoroReminderType.breakTimer.rawValue
+            // TODO: 分の数値を動的に変更
+            notificationTitle = "5分経ちました"
+            notificationBody = "業務に戻りましょう"
+        }
+        return ReminderNotificationData(reminderName: reminderName,
+                                        notificationTitle: notificationTitle,
+                                        notificationBody: notificationBody)
+    }
+}
+
+enum PomodoroReminderType: String {
+    case mainTimer
+    case breakTimer
+
+    static func fromIdentifier(_ identifier: String) -> PomodoroReminderType? {
+        PomodoroReminderType(rawValue: identifier)
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+Notification.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+Notification.swift
@@ -13,14 +13,14 @@ extension PomodoroTimerViewModel {
         guard isReminderActive else {
             return
         }
-        await sendPomodoroNotification(type: .mainTimer, interval: 15)
+        await sendPomodoroNotification(type: .mainTimer, interval: PomodoroTimerViewModel.MaxTimer)
     }
 
     func sendBreakTimerEndNotification() async {
         guard isReminderActive else {
             return
         }
-        await sendPomodoroNotification(type: .breakTimer, interval: 3)
+        await sendPomodoroNotification(type: .breakTimer, interval: PomodoroTimerViewModel.BreakTime)
     }
 
     func cancelCurrentNotification(type: PomodoroReminderType) {
@@ -42,7 +42,6 @@ extension PomodoroTimerViewModel {
         if checkStatus.authorizationStatus != .authorized {
             return
         }
-        // let requests = await center.pendingNotificationRequests()
         center.removePendingNotificationRequests(withIdentifiers: [reminderNotificationData.reminderName])
 
         let content = UNMutableNotificationContent()
@@ -66,26 +65,15 @@ extension PomodoroTimerViewModel {
         switch type {
         case .mainTimer:
             reminderName = PomodoroReminderType.mainTimer.rawValue
-            // TODO: 分の数値を動的に変更
-            notificationTitle = "25分経ちました"
+            notificationTitle = "\(formatPomodoroTime(PomodoroTimerViewModel.MaxTimer))経ちました"
             notificationBody = "休憩に入りましょう"
         case .breakTimer:
             reminderName = PomodoroReminderType.breakTimer.rawValue
-            // TODO: 分の数値を動的に変更
-            notificationTitle = "5分経ちました"
+            notificationTitle = "\(formatPomodoroTime(PomodoroTimerViewModel.BreakTime))経ちました"
             notificationBody = "業務に戻りましょう"
         }
         return ReminderNotificationData(reminderName: reminderName,
                                         notificationTitle: notificationTitle,
                                         notificationBody: notificationBody)
-    }
-}
-
-enum PomodoroReminderType: String {
-    case mainTimer
-    case breakTimer
-
-    static func fromIdentifier(_ identifier: String) -> PomodoroReminderType? {
-        PomodoroReminderType(rawValue: identifier)
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+StopTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+StopTimer.swift
@@ -1,0 +1,55 @@
+//
+//  PomodoroTimerViewModel+StopTimer.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/16.
+//
+
+import Foundation
+
+extension PomodoroTimerViewModel {
+    func pauseTimer() {
+        cancelNotification()
+        timer.invalidate()
+        timerMode = .paused
+    }
+
+    func resetTimer() {
+        cancelNotification()
+        timer.invalidate()
+        secondsLeft = PomodoroTimerViewModel.MaxTimer
+        currentMaxTime = PomodoroTimerViewModel.MaxTimer
+        timerMode = .initial
+        pomodoroGroupId = nil
+    }
+
+    func resumeTimer() {
+        if timerMode == .paused {
+            if currentMaxTime == PomodoroTimerViewModel.BreakTime {
+                timerMode = .breakMode
+            } else {
+                timerMode = .running
+            }
+            Task {
+                await resumeNotification()
+            }
+            timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                if secondsLeft == 0 {
+                    if timerMode == .running {
+                        endMainTimer()
+                    } else {
+                        resetTimer()
+                    }
+                } else {
+                    secondsLeft -= 1
+                }
+            }
+        }
+    }
+
+    private func cancelNotification() {
+        let type = timerMode == .breakMode ? PomodoroReminderType.breakTimer : PomodoroReminderType.mainTimer
+        cancelCurrentNotification(type: type)
+    }
+}

--- a/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+StopTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+StopTimer.swift
@@ -10,13 +10,13 @@ import Foundation
 extension PomodoroTimerViewModel {
     func pauseTimer() {
         cancelNotification()
-        timer.invalidate()
+        timer?.cancel()
         timerMode = .paused
     }
 
     func resetTimer() {
         cancelNotification()
-        timer.invalidate()
+        timer?.cancel()
         secondsLeft = PomodoroTimerViewModel.MaxTimer
         currentMaxTime = PomodoroTimerViewModel.MaxTimer
         timerMode = .initial
@@ -33,18 +33,7 @@ extension PomodoroTimerViewModel {
             Task {
                 await resumeNotification()
             }
-            timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-                guard let self else { return }
-                if secondsLeft == 0 {
-                    if timerMode == .running {
-                        endMainTimer()
-                    } else {
-                        resetTimer()
-                    }
-                } else {
-                    secondsLeft -= 1
-                }
-            }
+            startDispatchMainTimer()
         }
     }
 

--- a/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 
 class PomodoroTimerViewModel: BaseViewModel {
+    static let shared = PomodoroTimerViewModel()
     let dataSource: PomodoroDataSource
     let pomodoroReminderDataSource: PomodoroReminderDataSource
     static let MaxTimer: Int = 15
@@ -47,7 +48,7 @@ class PomodoroTimerViewModel: BaseViewModel {
     }()
 
     var pomodoroGroupId: UUID?
-    var timer = Timer()
+    var timer: DispatchSourceTimer?
 
     init(dataSource: PomodoroDataSource = PomodoroDataSource.shared,
          pomodoroReminderDataSource: PomodoroReminderDataSource = PomodoroReminderDataSource.shared) {
@@ -58,5 +59,9 @@ class PomodoroTimerViewModel: BaseViewModel {
         completedPomodoroCount = workTimeEndPomodoros.count
         pomodoroRemindeer = fetchReminder()
         isReminderActive = pomodoroRemindeer?.isActive ?? false
+    }
+
+    deinit {
+        timer?.cancel()
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
@@ -9,13 +9,20 @@ import Foundation
 import SwiftUI
 
 class PomodoroTimerViewModel: BaseViewModel {
-    private let dataSource: PomodoroDataSource
-    static let MaxTimer: Int = 1500
-    static let BreakTime: Int = 300
+    let dataSource: PomodoroDataSource
+    let pomodoroReminderDataSource: PomodoroReminderDataSource
+    static let MaxTimer: Int = 15
+    static let BreakTime: Int = 3
     @Published var timerMode: PomodoroTimerMode = .initial
     @Published var secondsLeft: Int = MaxTimer
     @Published var currentMaxTime: Int = MaxTimer
     @Published var completedPomodoroCount = 0
+    var timerStartTimestamp: Date?
+    var backgroundEntryTimestamp: Date?
+    var remain: Int = 0
+    var pomodoroRemindeer: PomodoroReminder?
+    var isReminderActive = false
+
     var progress: CGFloat {
         CGFloat(secondsLeft) / CGFloat(currentMaxTime)
     }
@@ -42,151 +49,14 @@ class PomodoroTimerViewModel: BaseViewModel {
     var pomodoroGroupId: UUID?
     var timer = Timer()
 
-    init(dataSource: PomodoroDataSource = PomodoroDataSource.shared) {
+    init(dataSource: PomodoroDataSource = PomodoroDataSource.shared,
+         pomodoroReminderDataSource: PomodoroReminderDataSource = PomodoroReminderDataSource.shared) {
         self.dataSource = dataSource
+        self.pomodoroReminderDataSource = pomodoroReminderDataSource
         super.init()
         let workTimeEndPomodoros = fetchCount()
         completedPomodoroCount = workTimeEndPomodoros.count
-    }
-
-    func startTimer() {
-        timer.invalidate()
-        secondsLeft = PomodoroTimerViewModel.MaxTimer
-        currentMaxTime = PomodoroTimerViewModel.MaxTimer
-        timerMode = .running
-        pomodoroGroupId = UUID()
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            if secondsLeft == 0 {
-                if timerMode == .running {
-                    endMainTimer()
-                } else {
-                    resetTimer()
-                }
-            } else {
-                secondsLeft -= 1
-            }
-        }
-    }
-
-    func startBraekMode() {
-        timer.invalidate()
-        secondsLeft = PomodoroTimerViewModel.BreakTime
-        currentMaxTime = PomodoroTimerViewModel.BreakTime
-        timerMode = .breakMode
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            if secondsLeft == 0 {
-                endBreakTimer()
-            } else {
-                secondsLeft -= 1
-            }
-        }
-    }
-
-    func pauseTimer() {
-        timer.invalidate()
-        timerMode = .paused
-    }
-
-    func resetTimer() {
-        timer.invalidate()
-        secondsLeft = PomodoroTimerViewModel.MaxTimer
-        currentMaxTime = PomodoroTimerViewModel.MaxTimer
-        timerMode = .initial
-        pomodoroGroupId = nil
-    }
-
-    func resumeTimer() {
-        if timerMode == .paused {
-            if currentMaxTime == PomodoroTimerViewModel.BreakTime {
-                timerMode = .breakMode
-            } else {
-                timerMode = .running
-            }
-            timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-                guard let self else { return }
-                if secondsLeft == 0 {
-                    if timerMode == .running {
-                        endMainTimer()
-                    } else {
-                        resetTimer()
-                    }
-                } else {
-                    secondsLeft -= 1
-                }
-            }
-        }
-    }
-
-    func endMainTimer() {
-        timer.invalidate()
-        secondsLeft = PomodoroTimerViewModel.BreakTime
-        currentMaxTime = PomodoroTimerViewModel.BreakTime
-        timerMode = .initial
-        guard let pomodoroGroupId else {
-            setError(withMessage: "不正な値です")
-            return
-        }
-        let pomodoro = Pomodoro(pomodoroGroupId: pomodoroGroupId.uuidString, activityType: .workTime)
-        do {
-            try dataSource.insertPomodoro(pomodoro: pomodoro)
-
-            let workTimeEndPomodoros = fetchCount()
-            completedPomodoroCount = workTimeEndPomodoros.count
-        } catch {
-            setError(withMessage: "登録処理に失敗しました", error: error)
-        }
-    }
-
-    func fetchCount() -> [Pomodoro] {
-        do {
-            let predicate = try createPredicateForOneDayPomodoro()
-            let pomodoros = try dataSource.fetchPomodoros(predicate: predicate)
-            let workTimeEndPomodoros = pomodoros.filter {
-                $0.activityType == .workTime
-            }
-            return workTimeEndPomodoros
-        } catch {
-            setError(withMessage: "取得処理に失敗しました", error: error)
-        }
-        return []
-    }
-
-    func endBreakTimer() {
-        guard let pomodoroGroupId else {
-            fatalError("不正な値です")
-        }
-        let pomodoro = Pomodoro(pomodoroGroupId: pomodoroGroupId.uuidString, activityType: .breakTime)
-
-        do {
-            try dataSource.insertPomodoro(pomodoro: pomodoro)
-            NotificationCenter.default.post(name: .didUpdatePomodoroData, object: nil)
-        } catch {
-            setError(withMessage: "登録処理に失敗しました", error: error)
-        }
-        resetTimer()
-    }
-
-    private func createPredicateForOneDayPomodoro() throws -> Predicate<Pomodoro> {
-        let (startOfDay, endOfDay) = try dayPeriod(for: Date())
-        // let workTimeType = PomodoroActivityType.workTime
-        let predicate = #Predicate<Pomodoro> { pomodoro in
-
-            pomodoro.registeredAt >= startOfDay && pomodoro.registeredAt < endOfDay
-            // TODO: xcodeのバージョンを上げたら直るか確認
-            // pomodoro.activityType == workTimeType
-        }
-        return predicate
-    }
-
-    private func dayPeriod(for date: Date) throws -> (startOfDay: Date, endOfDay: Date) {
-        let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: date)
-        let endOfDayComponents = DateComponents(day: 1)
-        guard let endOfDay = calendar.date(byAdding: endOfDayComponents, to: startOfDay) else {
-            throw DateError.calculationFailed(description: "Failed to calculate the end of day")
-        }
-        return (startOfDay, endOfDay)
+        pomodoroRemindeer = fetchReminder()
+        isReminderActive = pomodoroRemindeer?.isActive ?? false
     }
 }

--- a/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
@@ -9,11 +9,15 @@ import Foundation
 import SwiftUI
 
 class PomodoroTimerViewModel: BaseViewModel {
-    static let shared = PomodoroTimerViewModel()
+    private static let _shared = PomodoroTimerViewModel()
+    static func shared() -> PomodoroTimerViewModel {
+        _shared
+    }
+
     let dataSource: PomodoroDataSource
     let pomodoroReminderDataSource: PomodoroReminderDataSource
-    static let MaxTimer: Int = 15
-    static let BreakTime: Int = 3
+    static let MaxTimer: Int = 1500
+    static let BreakTime: Int = 300
     @Published var timerMode: PomodoroTimerMode = .initial
     @Published var secondsLeft: Int = MaxTimer
     @Published var currentMaxTime: Int = MaxTimer
@@ -21,7 +25,7 @@ class PomodoroTimerViewModel: BaseViewModel {
     var timerStartTimestamp: Date?
     var backgroundEntryTimestamp: Date?
     var remain: Int = 0
-    var pomodoroRemindeer: PomodoroReminder?
+    var pomodoroReminder: PomodoroReminder?
     var isReminderActive = false
 
     var progress: CGFloat {
@@ -55,10 +59,14 @@ class PomodoroTimerViewModel: BaseViewModel {
         self.dataSource = dataSource
         self.pomodoroReminderDataSource = pomodoroReminderDataSource
         super.init()
-        let workTimeEndPomodoros = fetchCount()
-        completedPomodoroCount = workTimeEndPomodoros.count
-        pomodoroRemindeer = fetchReminder()
-        isReminderActive = pomodoroRemindeer?.isActive ?? false
+        do {
+            let workTimeEndPomodoros = try fetchCount()
+            completedPomodoroCount = workTimeEndPomodoros.count
+            pomodoroReminder = try fetchReminder()
+            isReminderActive = pomodoroReminder?.isActive ?? false
+        } catch {
+            setError(withMessage: "初期取得処理に失敗しました", error: error)
+        }
     }
 
     deinit {

--- a/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
+++ b/RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
@@ -9,10 +9,7 @@ import Foundation
 import SwiftUI
 
 class PomodoroTimerViewModel: BaseViewModel {
-    private static let _shared = PomodoroTimerViewModel()
-    static func shared() -> PomodoroTimerViewModel {
-        _shared
-    }
+    static let shared = PomodoroTimerViewModel()
 
     let dataSource: PomodoroDataSource
     let pomodoroReminderDataSource: PomodoroReminderDataSource
@@ -60,10 +57,7 @@ class PomodoroTimerViewModel: BaseViewModel {
         self.pomodoroReminderDataSource = pomodoroReminderDataSource
         super.init()
         do {
-            let workTimeEndPomodoros = try fetchCount()
-            completedPomodoroCount = workTimeEndPomodoros.count
-            pomodoroReminder = try fetchReminder()
-            isReminderActive = pomodoroReminder?.isActive ?? false
+            try initializeDataSources()
         } catch {
             setError(withMessage: "初期取得処理に失敗しました", error: error)
         }
@@ -71,5 +65,12 @@ class PomodoroTimerViewModel: BaseViewModel {
 
     deinit {
         timer?.cancel()
+    }
+
+    func initializeDataSources() throws {
+        let workTimeEndPomodoros = try fetchCount()
+        completedPomodoroCount = workTimeEndPomodoros.count
+        pomodoroReminder = try fetchReminder()
+        isReminderActive = pomodoroReminder?.isActive ?? false
     }
 }

--- a/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PomodoroTimer: View {
-    @StateObject var viewModel = PomodoroTimerViewModel.shared
+    @StateObject var viewModel = PomodoroTimerViewModel.shared()
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -60,7 +60,7 @@ struct PomodoroTimer: View {
                 }
             } else if viewModel.currentMaxTime == PomodoroTimerViewModel.BreakTime {
                 PomodoroButton(title: "休憩開始", backgroundColor: Color.blue) {
-                    viewModel.startBraekMode()
+                    viewModel.startBreakMode()
                 }
             }
         case .running, .breakMode:

--- a/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PomodoroTimer: View {
     @StateObject var viewModel = PomodoroTimerViewModel()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         VStack {
@@ -34,6 +35,24 @@ struct PomodoroTimer: View {
             }
             .padding(40)
             timerModeView
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase == .background {
+                if viewModel.timerMode == .running || viewModel.timerMode == .breakMode {
+                    viewModel.backgroundSetTimer()
+                }
+            }
+            if scenePhase == .active {
+                if (viewModel.backgroundEntryTimestamp != nil) && viewModel.timerMode == .running || viewModel.timerMode == .breakMode {
+                    viewModel.syncTimerOnActive()
+                }
+            }
+            if scenePhase == .inactive {
+                print("バックグラウンドorフォアグラウンド直前（.inactive）")
+            }
+        }
+        .onChange(of: viewModel.secondsLeft) {
+            print("viewModel.secondsLeft", viewModel.secondsLeft)
         }
     }
 

--- a/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PomodoroTimer: View {
-    @StateObject var viewModel = PomodoroTimerViewModel.shared()
+    @StateObject var viewModel = PomodoroTimerViewModel.shared
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {

--- a/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
+++ b/RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PomodoroTimer: View {
-    @StateObject var viewModel = PomodoroTimerViewModel()
+    @StateObject var viewModel = PomodoroTimerViewModel.shared
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -25,7 +25,7 @@ struct PomodoroTimer: View {
                     .animation(.linear, value: viewModel.progress)
 
                 VStack {
-                    Text("\(formatPomodoroTime(viewModel.secondsLeft))")
+                    Text("\(viewModel.formatPomodoroTime(viewModel.secondsLeft))")
                         .font(.largeTitle)
                         .padding()
 
@@ -47,12 +47,6 @@ struct PomodoroTimer: View {
                     viewModel.syncTimerOnActive()
                 }
             }
-            if scenePhase == .inactive {
-                print("バックグラウンドorフォアグラウンド直前（.inactive）")
-            }
-        }
-        .onChange(of: viewModel.secondsLeft) {
-            print("viewModel.secondsLeft", viewModel.secondsLeft)
         }
     }
 
@@ -83,13 +77,6 @@ struct PomodoroTimer: View {
                 }
             }
         }
-    }
-
-    private func formatPomodoroTime(_ second: Int) -> String {
-        let formatter = viewModel.formatter
-
-        let formattedString = formatter.string(from: TimeInterval(second))!
-        return formattedString
     }
 }
 

--- a/RemoteWellnessSupportApp/Core/ModelManager.swift
+++ b/RemoteWellnessSupportApp/Core/ModelManager.swift
@@ -29,7 +29,9 @@ final class ModelManager {
 
     private init() {
         let schema = Schema([Hydration.self, HydrationReminder.self,
-                             PhysicalCondition.self, PhysicalConditionReminder.self, Profile.self, Pomodoro.self])
+                             PhysicalCondition.self,
+                             PhysicalConditionReminder.self, Profile.self,
+                             Pomodoro.self, PomodoroReminder.self])
         do {
             modelContainer = try ModelContainer(for: schema)
         } catch {

--- a/RemoteWellnessSupportApp/NotificationSetting/Enums/NotificationSettingNavigationItem.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/Enums/NotificationSettingNavigationItem.swift
@@ -11,5 +11,6 @@ enum NotificationSettingNavigationItem: Hashable {
     case notificationPermission
     case physicalConditionReminder
     case hydrationReminder
+    case pomodoroReminder
     case notificationSettingEnd
 }

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BasePomodoroReminder.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BasePomodoroReminder.swift
@@ -1,0 +1,17 @@
+//
+//  BasePomodoroReminder.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/15.
+//
+
+import Foundation
+
+class BasePomodoroReminder: BaseViewModel {
+    let dataSource: PomodoroReminderDataSource
+    @Published var isReminderActive = true
+
+    init(dataSource: PomodoroReminderDataSource = PomodoroReminderDataSource.shared) {
+        self.dataSource = dataSource
+    }
+}

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PomodoroReminderViewModel.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PomodoroReminderViewModel.swift
@@ -17,7 +17,7 @@ class PomodoroReminderViewModel: BasePomodoroReminder {
         return true
     }
 
-    private func insertPomodoroReminder(_ reminder: PomodoroReminder) -> Bool {
+    func insertPomodoroReminder(_ reminder: PomodoroReminder) -> Bool {
         do {
             try dataSource.insertPomodoroReminder(pomodoroReminder: reminder)
             return true

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PomodoroReminderViewModel.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PomodoroReminderViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  PomodoroReminderViewModel.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/15.
+//
+
+import Foundation
+
+class PomodoroReminderViewModel: BasePomodoroReminder {
+    func savePomodoroReminder() -> Bool {
+        let reminder = PomodoroReminder(isActive: isReminderActive)
+        guard insertPomodoroReminder(reminder) else {
+            setError(withMessage: "通知設定の登録に失敗しました")
+            return false
+        }
+        return true
+    }
+
+    private func insertPomodoroReminder(_ reminder: PomodoroReminder) -> Bool {
+        do {
+            try dataSource.insertPomodoroReminder(pomodoroReminder: reminder)
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/RemoteWellnessSupportApp/NotificationSetting/Views/Children/HydrationReminderView.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/Views/Children/HydrationReminderView.swift
@@ -19,7 +19,7 @@ struct HydrationReminderView: View {
             buttonAction: {
                 Task {
                     if await viewModel.saveHydrationReminder() {
-                        router.items.append(.notificationSettingEnd)
+                        router.items.append(.pomodoroReminder)
                     }
                 }
             }

--- a/RemoteWellnessSupportApp/NotificationSetting/Views/Children/PomodoroReminderView.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/Views/Children/PomodoroReminderView.swift
@@ -1,0 +1,36 @@
+//
+//  PomodoroReminderView.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/05/14.
+//
+
+import SwiftUI
+
+struct PomodoroReminderView: View {
+    @StateObject var viewModel = PomodoroReminderViewModel()
+    @EnvironmentObject private var router: NotificationSettingNavigationRouter
+    var body: some View {
+        VStack(spacing: 10) {
+            Text("ポモドーロリマインダーについて設定して下さい")
+                .font(.title)
+                .padding(.top, 10)
+
+            Toggle(isOn: $viewModel.isReminderActive) {
+                Text("通知設定の有無")
+            }
+            .padding()
+
+            Spacer()
+
+            CommonButtonView(title: "次へ進む") {
+                if viewModel.savePomodoroReminder() {
+                    router.items.append(.notificationSettingEnd)
+                }
+            }
+            .padding(.bottom, 50)
+        }
+        .padding(.horizontal, 10)
+        .modifier(ErrorAlertModifier(isErrorAlert: $viewModel.isErrorAlert, errorMessage: $viewModel.errorMessage))
+    }
+}

--- a/RemoteWellnessSupportApp/NotificationSetting/Views/NotificationSettingScreen.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/Views/NotificationSettingScreen.swift
@@ -20,6 +20,8 @@ struct NotificationSettingScreen: View {
                         PhysicalConditionReminderView()
                     case .hydrationReminder:
                         HydrationReminderView()
+                    case .pomodoroReminder:
+                        PomodoroReminderView()
                     case .notificationSettingEnd:
                         NotificationSettingEndView()
                             .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- 新しいデータソースクラス `PomodoroReminderDataSource` とモデル `PomodoroReminder` を追加
- ポモドーロタイマーの開始、停止、リセット、通知機能を追加
- バックグラウンドとアクティブ状態でのタイマー同期処理を追加
- ポモドーロリマインダー設定画面とその関連ビュー、ビューモデルを追加
- Xcodeプロジェクトファイルを更新し、新しいファイルの参照を追加


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>PomodoroReminderDataSource.swift</strong><dd><code>`PomodoroReminderDataSource` クラスの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Common/DataSources/PomodoroReminderDataSource.swift
<li>新しいデータソースクラス <code>PomodoroReminderDataSource</code> を追加<br> <li> ポモドーロリマインダーの挿入と取得メソッドを実装<br>


</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-03b8893e914da965b19af9ae60f3a6ff9a14ebc88cc7ca06f584f229c22c5b59">+34/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroReminder.swift</strong><dd><code>`PomodoroReminder` モデルの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Common/Models/PomodoroReminder.swift
- 新しいモデルクラス `PomodoroReminder` を追加
- リマインダーの属性を定義



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-80649a169c8e90b4b4212e431e2d0a7df30f7981e4e6c40a7dfd0c7dc7f44c94">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroReminderType.swift</strong><dd><code>`PomodoroReminderType` 列挙型の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Enums/PomodoroReminderType.swift
- 新しい列挙型 `PomodoroReminderType` を追加
- タイマーの種類を定義



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-9c7c2497f603ba968024e168711c026aae3c7e31572f5087e5d11d68ce2b2ca6">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+BreakTimer.swift</strong><dd><code>ブレイクタイマーの処理を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+BreakTimer.swift
- ブレイクタイマーの開始と終了メソッドを追加
- ディスパッチタイマーの設定を実装



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-31744548e7fd39e1f204b2163ae32468153458f57c247b4629d375899bd4a4a1">+52/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+CommonProcessTimer.swift</strong><dd><code>タイマーのバックグラウンド同期処理を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+CommonProcessTimer.swift
- バックグラウンドとアクティブ状態でのタイマー同期メソッドを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-aadc8373abe82b9c713f4852b210161c9ff12b32b301c246b64a73c8c79ce256">+39/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+FetchReminder.swift</strong><dd><code>リマインダー取得機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchReminder.swift
- リマインダーの取得メソッドを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-fa311f275f8ef9881ff892bc15b9ce9bbbdab01054f5c3514a29b475edf5ebbb">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+FetchTimer.swift</strong><dd><code>ポモドーロカウント取得機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+FetchTimer.swift
- ポモドーロのカウントを取得するメソッドを追加
- 一日のポモドーロをフィルタリングするための述語を作成



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-be6b604bbb7a18b653ca45edd6eaedac0598088fd6da79e647db4cce49a86bce">+46/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+MainTimer.swift</strong><dd><code>メインタイマーの処理を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+MainTimer.swift
- メインタイマーの開始と終了メソッドを追加
- ディスパッチタイマーの設定を実装



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-c331ef8eae38b20f798346fe4cebeb9993250816756740f4a3c558cfa81fdd0e">+63/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+Notification.swift</strong><dd><code>タイマー通知機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+Notification.swift
- タイマー終了時の通知送信メソッドを追加
- 通知のキャンセルと再開メソッドを実装



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-d9664649f5875facbf71db533cf5f0a43bd49a7b249428e4f142eeae764a13c2">+79/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel+StopTimer.swift</strong><dd><code>タイマーの停止と再開機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/Extensions/PomodoroTimerViewModel+StopTimer.swift
- タイマーの一時停止、リセット、再開メソッドを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-d5ea751828745da91ba8ba13c8496300563a2f91a53385689c78aa02c067f6c5">+44/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimerViewModel.swift</strong><dd><code>`PomodoroTimerViewModel` のリファクタリングと機能追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/ViewModels/PomodoroTimerViewModel.swift
- シングルトンインスタンスの追加
- 新しいデータソースとリマインダーデータソースの統合
- タイマー関連のプロパティとメソッドを更新



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-9966303864766a9c5ed2d8d0ae8ef5464f66c704b52698c77e167a4b3407a1c3">+19/-144</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroTimer.swift</strong><dd><code>`PomodoroTimer` ビューの更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Condition/Views/Children/PomodoroTimer.swift
- タイマーの表示とシーンフェーズの変更に対応



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-828e3f800e25dda1282327a4143a5a7be85a2d613f64b6a28061c4b1239356cb">+15/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ModelManager.swift</strong><dd><code>モデルマネージャーに `PomodoroReminder` を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Core/ModelManager.swift
- `PomodoroReminder` モデルをスキーマに追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-7c412e70cc72e7987287b47a1446e777d29d7e74a8c46d6fc049ce91efe583e3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NotificationSettingNavigationItem.swift</strong><dd><code>ナビゲーションアイテムにポモドーロリマインダーを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/Enums/NotificationSettingNavigationItem.swift
- ポモドーロリマインダーのナビゲーションアイテムを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-271cfb62c30ad71ac7034e20f846005d402e1df349de34846e80a98804b15e9f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BasePomodoroReminder.swift</strong><dd><code>基底クラス `BasePomodoroReminder` の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BasePomodoroReminder.swift
- 基底クラス `BasePomodoroReminder` を追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-9fd719a395ce071e891171f4923d112302331485275298d4980f9b98ed9ff08c">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroReminderViewModel.swift</strong><dd><code>`PomodoroReminderViewModel` の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/ViewModels/PomodoroReminderViewModel.swift
- ポモドーロリマインダーの保存メソッドを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-82be019c713930f14aff111356e8a6e3ea72d9a011cf9107f7fb1b8c590bc5ba">+28/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HydrationReminderView.swift</strong><dd><code>`HydrationReminderView` の更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/Views/Children/HydrationReminderView.swift
- ポモドーロリマインダーへの遷移を追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-e040a7dddc9bfa507510ad7100bfd2d080a68913775df21d4f1d06a9f5d591a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PomodoroReminderView.swift</strong><dd><code>`PomodoroReminderView` の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/Views/Children/PomodoroReminderView.swift
- ポモドーロリマインダー設定画面を追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-fcb37fea81a0e543caeb4e3ac167c91934c0fe69fb1510af3987c6d57fae2334">+36/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NotificationSettingScreen.swift</strong><dd><code>`NotificationSettingScreen` の更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/Views/NotificationSettingScreen.swift
- ポモドーロリマインダー設定画面へのナビゲーションを追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-83408454cc302ee343b02a758cd2f37da58459d7f92a18134c676e815f735bed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Xcodeプロジェクトファイルの更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp.xcodeproj/project.pbxproj
- 新しいファイルの参照を追加



</details>
    

  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/26/files#diff-416f90ec0839507819964497c1a1d436c175cdeb595a1cc542713b25c07ff813">+60/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ポモドーロリマインダー機能を追加しました。
  - ポモドーロタイマー管理機能を追加しました。

- **改善**
  - `PomodoroTimerViewModel`のプロパティとメソッドを更新しました。
  - `NotificationSettingScreen`にポモドーロリマインダーの設定機能を追加しました。

- **バグ修正**
  - `HydrationReminderView`のロジックを更新し、ポモドーロリマインダー項目を処理するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->