### PR TITLE
feat: １時間あたりに座りっぱなしになっていないかを計測できるように対応

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -12,10 +12,10 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: Set up Swift
+    - name: Set up Xcode 15
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 'latest'
+        xcode-version: '15'
 
     - name: Cache Swift dependencies
       uses: actions/cache@v3

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
-          "version": "1.8.1"
+          "revision": "678d442c6f7828def400a70ae15968aef67ef52d",
+          "version": "1.8.3"
         }
       },
       {

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [.macOS(.v10_11)],
     dependencies: [
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.49.0"),
-        .package(url: "https://github.com/realm/SwiftLint", from: "0.53.0")
+        .package(url: "https://github.com/realm/SwiftLint", .exact("0.54.0"))
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		2E0DA4252B8D5DC4004E0185 /* GraphDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4242B8D5DC4004E0185 /* GraphDefinition.swift */; };
 		2E0DA4282B8E10EB004E0185 /* ChartXAxisModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4272B8E10EB004E0185 /* ChartXAxisModifier.swift */; };
 		2E0DA42A2B8E113D004E0185 /* PhysicalConditionChartYModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DA4292B8E113D004E0185 /* PhysicalConditionChartYModifier.swift */; };
+		2E10CEEC2C6C1BF5008B041D /* StandHourPermissionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E10CEEB2C6C1BF5008B041D /* StandHourPermissionViewModel.swift */; };
 		2E1194A12BE46D0E00DB4BD3 /* WorkDaySelectEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A02BE46D0E00DB4BD3 /* WorkDaySelectEditViewModel.swift */; };
 		2E1194A32BE4773A00DB4BD3 /* WorkTimeEditInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A22BE4773A00DB4BD3 /* WorkTimeEditInputView.swift */; };
 		2E1194A52BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A42BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift */; };
@@ -44,6 +45,7 @@
 		2E1194A92BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1194A82BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift */; };
 		2E16966E2C03F6B900D540BD /* PomodoroReminderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E16966D2C03F6B900D540BD /* PomodoroReminderType.swift */; };
 		2E17831F2BE0537200F07B97 /* ProfileSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E17831E2BE0537200F07B97 /* ProfileSettingViewModel.swift */; };
+		2E35BB512C6AC67000CDAEFC /* StandHourPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E35BB502C6AC66F00CDAEFC /* StandHourPermissionView.swift */; };
 		2E50E67E2BE2FC2F00068916 /* NicknameEditInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E67D2BE2FC2F00068916 /* NicknameEditInputViewModel.swift */; };
 		2E50E6802BE305EC00068916 /* WorkDaySelectEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E67F2BE305EC00068916 /* WorkDaySelectEditView.swift */; };
 		2E57473A2BC55E2600B46C55 /* StepGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5747392BC55E2600B46C55 /* StepGraph.swift */; };
@@ -297,6 +299,7 @@
 		2E0DA4242B8D5DC4004E0185 /* GraphDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphDefinition.swift; sourceTree = "<group>"; };
 		2E0DA4272B8E10EB004E0185 /* ChartXAxisModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartXAxisModifier.swift; sourceTree = "<group>"; };
 		2E0DA4292B8E113D004E0185 /* PhysicalConditionChartYModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalConditionChartYModifier.swift; sourceTree = "<group>"; };
+		2E10CEEB2C6C1BF5008B041D /* StandHourPermissionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandHourPermissionViewModel.swift; sourceTree = "<group>"; };
 		2E1194A02BE46D0E00DB4BD3 /* WorkDaySelectEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkDaySelectEditViewModel.swift; sourceTree = "<group>"; };
 		2E1194A22BE4773A00DB4BD3 /* WorkTimeEditInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkTimeEditInputView.swift; sourceTree = "<group>"; };
 		2E1194A42BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkTimeEditInputViewModel.swift; sourceTree = "<group>"; };
@@ -304,6 +307,7 @@
 		2E1194A82BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimeEditInputViewModel.swift; sourceTree = "<group>"; };
 		2E16966D2C03F6B900D540BD /* PomodoroReminderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroReminderType.swift; sourceTree = "<group>"; };
 		2E17831E2BE0537200F07B97 /* ProfileSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewModel.swift; sourceTree = "<group>"; };
+		2E35BB502C6AC66F00CDAEFC /* StandHourPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandHourPermissionView.swift; sourceTree = "<group>"; };
 		2E50E67D2BE2FC2F00068916 /* NicknameEditInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditInputViewModel.swift; sourceTree = "<group>"; };
 		2E50E67F2BE305EC00068916 /* WorkDaySelectEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkDaySelectEditView.swift; sourceTree = "<group>"; };
 		2E5747392BC55E2600B46C55 /* StepGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepGraph.swift; sourceTree = "<group>"; };
@@ -1007,6 +1011,7 @@
 				2E1194A42BE4794300DB4BD3 /* WorkTimeEditInputViewModel.swift */,
 				2E1194A82BE5BCE000DB4BD3 /* RestTimeEditInputViewModel.swift */,
 				2ED5FF0E2BE64F820025113D /* GoalSettingEditInputViewModel.swift */,
+				2E10CEEB2C6C1BF5008B041D /* StandHourPermissionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1020,6 +1025,7 @@
 				2EB942002BADAA2300F3B0D2 /* WorkDaySelectView.swift */,
 				2EB942042BAEBF2500F3B0D2 /* WorkTimeInputView.swift */,
 				2EB942082BAECC9200F3B0D2 /* RestTimeInputView.swift */,
+				2E35BB502C6AC66F00CDAEFC /* StandHourPermissionView.swift */,
 			);
 			path = Children;
 			sourceTree = "<group>";
@@ -1618,6 +1624,7 @@
 				2E0A11F12C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift in Sources */,
 				2E041C212BDCD8DA0082CBD6 /* StepProgressViewModel.swift in Sources */,
 				2E6983692B9C73E80076EF4F /* WeekPhysicalConditionGraphViewModel.swift in Sources */,
+				2E35BB512C6AC67000CDAEFC /* StandHourPermissionView.swift in Sources */,
 				2E61D0BD2BB302190087B895 /* HydrationChartYModifier.swift in Sources */,
 				2E9D61E42BEEFB5D00C8F062 /* HydrationReminderDataSource.swift in Sources */,
 				2EB9421B2BAFC85200F3B0D2 /* BaseViewModel.swift in Sources */,
@@ -1701,6 +1708,7 @@
 				2EE812E72B79A6F0000B65E5 /* ActivityEntryNavigationLink.swift in Sources */,
 				2E9D61E22BEEF98F00C8F062 /* BaseHydrationReminder.swift in Sources */,
 				2EB4D52E2BE6FE3C00FF4A2A /* ReminderSettingViewModel.swift in Sources */,
+				2E10CEEC2C6C1BF5008B041D /* StandHourPermissionViewModel.swift in Sources */,
 				2EE812CA2B79016D000B65E5 /* TodayCondition.swift in Sources */,
 				2ED5FF0D2BE64C620025113D /* GoalSettingEditInputView.swift in Sources */,
 				2EE812D82B79904E000B65E5 /* HydrationEntryForm.swift in Sources */,

--- a/RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift
+++ b/RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift
@@ -11,6 +11,7 @@ enum ProfileNavigationItem: Hashable {
     case workDaySelect
     case workTimeInput
     case restTimeInput
+    case standHourPermission
     case goalSettingInput
 }
 

--- a/RemoteWellnessSupportApp/Profile/ViewModels/StandHourPermissionViewModel.swift
+++ b/RemoteWellnessSupportApp/Profile/ViewModels/StandHourPermissionViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  StandHourPermissionViewModel.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/08/14.
+//
+
+import Foundation
+import HealthKit
+
+@MainActor
+final class StandHourPermissionViewModel: BaseViewModel {
+    var manager: HealthKitManager
+    let standHourType = HKObjectType.categoryType(forIdentifier: .appleStandHour)!
+    @Published var isDoneAuthorizeRequest = false
+    @Published var isLoading = false
+
+    override init() {
+        manager = HealthKitManager()
+        super.init()
+    }
+
+    func authorizeHealthKit() async {
+        isLoading = true
+        do {
+            try await manager.authorizeHealthKit(toShare: [], read: [standHourType])
+            isDoneAuthorizeRequest = true
+            isLoading = false
+        } catch {
+            setError(withMessage: "ヘルスケアの認証処理に失敗しました", error: error)
+        }
+    }
+}

--- a/RemoteWellnessSupportApp/Profile/Views/Children/StandHourPermissionView.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/Children/StandHourPermissionView.swift
@@ -1,0 +1,44 @@
+//
+//  StandHourPermissionView.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/08/13.
+//
+
+import SwiftUI
+
+struct StandHourPermissionView: View {
+    @EnvironmentObject var router: ProfileNavigationRouter
+    @StateObject var viewModel = StandHourPermissionViewModel()
+
+    var body: some View {
+        CommonLayoutView(
+            title: "座りっぱなしかどうかを確認するための設定を行なってください",
+            buttonTitle: "次へ進む",
+            content: {
+                if viewModel.isLoading {
+                    ProgressView("ヘルスケアの許可を求めています…")
+                        .progressViewStyle(CircularProgressViewStyle())
+                        .padding()
+                } else {
+                    Text("許可しないを選択した場合でも、後に設定変更から許可を変更することができます")
+                        .font(.body)
+                }
+            },
+            buttonAction: {
+                router.items.append(.goalSettingInput)
+            },
+            isFirstView: false,
+            isButtonDisabled: viewModel.isLoading
+        )
+        .onAppear {
+            Task {
+                await viewModel.authorizeHealthKit()
+            }
+        }
+    }
+}
+
+#Preview {
+    StandHourPermissionView()
+}

--- a/RemoteWellnessSupportApp/Profile/Views/Children/WorkTimeInputView.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/Children/WorkTimeInputView.swift
@@ -23,7 +23,7 @@ struct WorkTimeInputView: View {
             },
             buttonAction: {
                 if viewModel.inputValidate(workTimeFrom: workTimeFrom, workTimeTo: workTimeTo) {
-                    router.items.append(.restTimeInput)
+                    router.items.append(.standHourPermission)
                 }
             }
         )

--- a/RemoteWellnessSupportApp/Profile/Views/Common/CommonLayoutView.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/Common/CommonLayoutView.swift
@@ -13,13 +13,17 @@ struct CommonLayoutView<Content>: View where Content: View {
     let buttonAction: () -> Void
     let content: Content
     let isFirstView: Bool
+    let isButtonDisabled: Bool
 
-    init(title: String, buttonTitle: String, @ViewBuilder content: () -> Content, buttonAction: @escaping () -> Void, isFirstView: Bool = false) {
+    init(title: String, buttonTitle: String,
+         @ViewBuilder content: () -> Content, buttonAction: @escaping () -> Void,
+         isFirstView: Bool = false, isButtonDisabled: Bool = false) {
         self.title = title
         self.buttonTitle = buttonTitle
         self.buttonAction = buttonAction
         self.content = content()
         self.isFirstView = isFirstView
+        self.isButtonDisabled = isButtonDisabled
     }
 
     var body: some View {
@@ -27,7 +31,7 @@ struct CommonLayoutView<Content>: View where Content: View {
             TitleView(text: title)
             content
             Spacer()
-            CommonButtonView(title: buttonTitle, action: buttonAction)
+            CommonButtonView(title: buttonTitle, disabled: isButtonDisabled, action: buttonAction)
         }
         .modifier(CommonPaddingModifier(horizontal: 10, verticalTop: isFirstView ? 70 : 30, verticalBottom: 70))
     }

--- a/RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift
@@ -30,6 +30,8 @@ struct ProfileScreen: View {
             WorkTimeInputView(workTimeFrom: $viewModel.workTimeFrom, workTimeTo: $viewModel.workTimeTo)
         case .restTimeInput:
             RestTimeInputView(restTimePeriodSections: $viewModel.restTimePeriodSections)
+        case .standHourPermission:
+            StandHourPermissionView()
         case .goalSettingInput:
             GoalSettingInputView(hydrationGoal: $viewModel.hydrationGoal) {
                 viewModel.saveProfile()

--- a/RemoteWellnessSupportApp/Setting/ViewModels/ProfileSettingViewModel.swift
+++ b/RemoteWellnessSupportApp/Setting/ViewModels/ProfileSettingViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class ProfileSettingViewModel: BaseViewModel {
     private let dataSource: ProfileDataSource
     @Published var profileRecord: Profile?
+    @Published var isOpenAlert = false
 
     var workDaysLabels: String {
         guard let profile = profileRecord else {

--- a/RemoteWellnessSupportApp/Setting/Views/Children/ProfileSettingView.swift
+++ b/RemoteWellnessSupportApp/Setting/Views/Children/ProfileSettingView.swift
@@ -69,10 +69,43 @@ struct ProfileSettingView: View {
                             })
                         }
                     }
+
+                    Section(header: Text("ヘルスケア連携項目設定")) {
+                        HStack {
+                            Text("アプリ設定を開く")
+                            Spacer()
+                            Button(action: {
+                                viewModel.isOpenAlert = true
+                            }, label: {
+                                Image(systemName: "arrow.up.forward.app.fill")
+                            })
+                        }
+                    }
                 }
 
             } else {
                 Text("プロファイル情報が存在しません")
+            }
+        }
+        .alert("ヘルスケア設定の案内", isPresented: $viewModel.isOpenAlert) {
+            Button("OK") {
+                openAppSettings()
+            }
+        } message: {
+            Text("""
+            1. まず画面左上の「設定」をタップしてください。
+            2. 次に「ヘルスケア」をタップしてください。
+            3. さらに「データアクセスとデバイス」を選択してください。
+            4. 対象のアプリ名を選び、読み取り権限をオン・オフを確認または変更してください。
+            5. 設定が完了したら、アプリに戻ってください。
+            """)
+        }
+    }
+
+    private func openAppSettings() {
+        if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
+            if UIApplication.shared.canOpenURL(settingsUrl) {
+                UIApplication.shared.open(settingsUrl)
             }
         }
     }

--- a/RemoteWellnessSupportApp/Setting/Views/Children/ProfileSettingView.swift
+++ b/RemoteWellnessSupportApp/Setting/Views/Children/ProfileSettingView.swift
@@ -103,10 +103,8 @@ struct ProfileSettingView: View {
     }
 
     private func openAppSettings() {
-        if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
-            if UIApplication.shared.canOpenURL(settingsUrl) {
-                UIApplication.shared.open(settingsUrl)
-            }
+        if let settingsUrl = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(settingsUrl) {
+            UIApplication.shared.open(settingsUrl)
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new feature to measure if the user is sitting for too long by integrating HealthKit authorization.
- Implemented `StandHourPermissionViewModel` to handle HealthKit authorization requests.
- Created `StandHourPermissionView` to provide a user interface for requesting HealthKit permissions.
- Updated navigation logic to include the new `standHourPermission` step.
- Enhanced `CommonLayoutView` to support disabling buttons based on loading state.
- Added guidance in `ProfileSettingView` for users to manage HealthKit settings through app settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ProfileNavigationRouter.swift</strong><dd><code>Add standHourPermission case to ProfileNavigationItem</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift

<li>Added a new case <code>standHourPermission</code> to <code>ProfileNavigationItem</code> enum.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-0800e64922bb7a5ffa529b55a334ca7194b4b463bfe64dd70851b0d5658037a1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StandHourPermissionViewModel.swift</strong><dd><code>Implement StandHourPermissionViewModel for HealthKit authorization</code></dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/ViewModels/StandHourPermissionViewModel.swift

<li>Created <code>StandHourPermissionViewModel</code> class.<br> <li> Added HealthKit authorization logic.<br> <li> Introduced state variables for authorization status and loading.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-0e06b140337a2f29a1eb1d4da5cabdb05b02318d9522b744d94fb1475d3e5abf">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StandHourPermissionView.swift</strong><dd><code>Create StandHourPermissionView for user interaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/Children/StandHourPermissionView.swift

<li>Created <code>StandHourPermissionView</code> struct.<br> <li> Integrated with <code>StandHourPermissionViewModel</code>.<br> <li> Added UI components for HealthKit permission request.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-cbd6132f5c1d38800baf66ec86bb3038afe10df6e0c87da3a1a60fa41410a559">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WorkTimeInputView.swift</strong><dd><code>Update navigation to include standHourPermission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/Children/WorkTimeInputView.swift

- Updated navigation logic to include `standHourPermission`.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-866a011df45a3c4a944a33a85feb27cd8a2c124e3a42fed10cfe1fcf1b1606d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CommonLayoutView.swift</strong><dd><code>Enhance CommonLayoutView with button disable feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/Common/CommonLayoutView.swift

<li>Added <code>isButtonDisabled</code> parameter to <code>CommonLayoutView</code>.<br> <li> Updated button logic to respect the disabled state.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-a7cfeaf53dd0793ca348900d318e07a06f85810d0e873999e497a6642f04cada">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileScreen.swift</strong><dd><code>Integrate StandHourPermissionView into ProfileScreen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift

- Added `StandHourPermissionView` to the navigation cases.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-615bb5e39b9e1ce982b98c3d33ce17c819cc96da427f3d3b580c361d1ae9a256">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileSettingViewModel.swift</strong><dd><code>Add alert state management to ProfileSettingViewModel</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Setting/ViewModels/ProfileSettingViewModel.swift

- Introduced `isOpenAlert` state variable.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-dd70c285c0596d8f24d3566f58d6dad1741b85c926813599401ec49e058578bf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileSettingView.swift</strong><dd><code>Add HealthKit settings guidance in ProfileSettingView</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Setting/Views/Children/ProfileSettingView.swift

<li>Added section for HealthKit settings guidance.<br> <li> Implemented alert for guiding users to app settings.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-dd37d4f9da2978f9cccd2058f59736452a35301ec3038c369db1d1b2dcbfe66e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Update Xcode project with new view and view model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp.xcodeproj/project.pbxproj

<li>Added new files <code>StandHourPermissionViewModel.swift</code> and <br><code>StandHourPermissionView.swift</code> to the project.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/31/files#diff-416f90ec0839507819964497c1a1d436c175cdeb595a1cc542713b25c07ff813">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - スタンディング時間の許可を管理するための新しいユーザーインターフェースコンポーネントを追加しました。
  - プロファイルセクションにスタンディング時間の許可を管理するためのナビゲーションオプションを追加しました。
  - ユーザーがヘルスケアアプリの設定を変更するための明確な指示を提供するアラートを追加しました。
  - プロファイル設定におけるアラート管理のための新しい状態管理プロパティを追加しました。

- **バグ修正**
  - 特になし

- **ドキュメント**
  - ユーザー通知や確認メッセージの管理を改善するための状態管理を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->