### PR TITLE
feat: 通知画面をHome画面以降に出るように修正

### DIFF
--- a/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
+++ b/RemoteWellnessSupportApp.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		2E712E2B2BE1AA35004F574D /* Double+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E712E2A2BE1AA35004F574D /* Double+Extensions.swift */; };
 		2E712E2E2BE1ACFE004F574D /* NicknameEditInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E712E2D2BE1ACFE004F574D /* NicknameEditInputView.swift */; };
 		2E782F9C2BDDD598008B00F7 /* Notification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E782F9B2BDDD598008B00F7 /* Notification+Extensions.swift */; };
+		2E7B7CD32C7191A800BF619A /* ProfileEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7B7CD22C7191A800BF619A /* ProfileEndView.swift */; };
 		2E7EC78B2BD09CB400EF4854 /* Pomodoro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7EC78A2BD09CB400EF4854 /* Pomodoro.swift */; };
 		2E868AB22BB59D5A00681E6B /* WeekHydrationGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E868AB12BB59D5A00681E6B /* WeekHydrationGraph.swift */; };
 		2E868AB42BB59D6B00681E6B /* WeekHydrationGraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E868AB32BB59D6B00681E6B /* WeekHydrationGraphViewModel.swift */; };
@@ -349,6 +350,7 @@
 		2E712E2A2BE1AA35004F574D /* Double+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extensions.swift"; sourceTree = "<group>"; };
 		2E712E2D2BE1ACFE004F574D /* NicknameEditInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameEditInputView.swift; sourceTree = "<group>"; };
 		2E782F9B2BDDD598008B00F7 /* Notification+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extensions.swift"; sourceTree = "<group>"; };
+		2E7B7CD22C7191A800BF619A /* ProfileEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEndView.swift; sourceTree = "<group>"; };
 		2E7EC78A2BD09CB400EF4854 /* Pomodoro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pomodoro.swift; sourceTree = "<group>"; };
 		2E868AB12BB59D5A00681E6B /* WeekHydrationGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekHydrationGraph.swift; sourceTree = "<group>"; };
 		2E868AB32BB59D6B00681E6B /* WeekHydrationGraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekHydrationGraphViewModel.swift; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 				2EB942042BAEBF2500F3B0D2 /* WorkTimeInputView.swift */,
 				2EB942082BAECC9200F3B0D2 /* RestTimeInputView.swift */,
 				2E35BB502C6AC66F00CDAEFC /* StandHourPermissionView.swift */,
+				2E7B7CD22C7191A800BF619A /* ProfileEndView.swift */,
 			);
 			path = Children;
 			sourceTree = "<group>";
@@ -1619,6 +1622,7 @@
 				2E8FBEDE2BA86E660082B3E1 /* IntervalTimeSelectView.swift in Sources */,
 				2EA2C59D2BF0564F00F7751D /* HydrationReminderEditView.swift in Sources */,
 				2E712E2E2BE1ACFE004F574D /* NicknameEditInputView.swift in Sources */,
+				2E7B7CD32C7191A800BF619A /* ProfileEndView.swift in Sources */,
 				2EA2C5992BF0454F00F7751D /* ReminderNotificationData.swift in Sources */,
 				2ED5FF0F2BE64F820025113D /* GoalSettingEditInputViewModel.swift in Sources */,
 				2E0A11F12C0194C3001CE56F /* PomodoroTimerViewModel+CommonProcessTimer.swift in Sources */,

--- a/RemoteWellnessSupportApp/Navigation/Views/RootView.swift
+++ b/RemoteWellnessSupportApp/Navigation/Views/RootView.swift
@@ -9,16 +9,12 @@ import SwiftUI
 
 struct RootView: View {
     @AppStorage(Const.AppStatus.hasCompletedOnboarding) var hasCompletedOnboarding: Bool = Const.AppDefaults.hasCompletedOnboarding
-    @AppStorage(Const.AppStatus.hasCompletedNotificationSetting) var hasCompletedNotificationSetting
-        = Const.AppDefaults.hasCompletedNotificationSetting
     @AppStorage(Const.AppStatus.hasCompletedProfileRegister) var hasCompletedProfileRegister
         = Const.AppDefaults.hasCompletedProfileRegister
 
     var body: some View {
-        if hasCompletedNotificationSetting {
+        if hasCompletedProfileRegister {
             MainView()
-        } else if hasCompletedProfileRegister {
-            NotificationSettingScreen()
         } else if hasCompletedOnboarding {
             ProfileScreen()
         } else {

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BaseReminderScheduler.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BaseReminderScheduler.swift
@@ -33,6 +33,26 @@ class BaseReminderScheduler: BaseViewModel {
         return true
     }
 
+    func removeNotification(for reminder: BaseReminderProtocol, type: ReminderType) async {
+        if reminder.isActive {
+            return
+        }
+
+        let reminderNotificationData = dataForReminderType(type: type)
+        let center = UNUserNotificationCenter.current()
+
+        let checkStatus = await center.notificationSettings()
+        if checkStatus.authorizationStatus != .authorized {
+            return
+        }
+        let requests = await center.pendingNotificationRequests()
+        let hasPhysicalConditionReminder = requests.contains { $0.identifier == reminderNotificationData.reminderName }
+
+        if hasPhysicalConditionReminder {
+            center.removePendingNotificationRequests(withIdentifiers: [reminderNotificationData.reminderName])
+        }
+    }
+
     func sendNotification(for reminder: BaseReminderProtocol, type: ReminderType) async -> Bool {
         if !reminder.isActive {
             return true

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/HydrationReminderEditViewModel.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/HydrationReminderEditViewModel.swift
@@ -27,7 +27,13 @@ class HydrationReminderEditViewModel: BaseHydrationReminder, ReminderViewModelPr
             setError(withMessage: "水分摂取通知設定の更新に失敗しました")
             return false
         }
-        return await sendNotification(for: hydrationReminder, type: .hydration)
+        if hydrationReminder.isActive {
+            return await sendNotification(for: hydrationReminder, type: .hydration)
+
+        } else {
+            await removeNotification(for: hydrationReminder, type: .hydration)
+            return true
+        }
     }
 
     private func assignHydrationReminderForUpdate() {

--- a/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PhysicalConditionReminderEditViewModel.swift
+++ b/RemoteWellnessSupportApp/NotificationSetting/ViewModels/PhysicalConditionReminderEditViewModel.swift
@@ -27,8 +27,12 @@ class PhysicalConditionReminderEditViewModel: BasePhysicalConditionReminder, Rem
             setError(withMessage: "体調通知設定の更新に失敗しました")
             return false
         }
-
-        return await sendNotification(for: physicalConditionReminder, type: .physicalCondition)
+        if physicalConditionReminder.isActive {
+            return await sendNotification(for: physicalConditionReminder, type: .physicalCondition)
+        } else {
+            await removeNotification(for: physicalConditionReminder, type: .physicalCondition)
+            return true
+        }
     }
 
     private func assignPhysicalConditionReminderForUpdate() {

--- a/RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift
+++ b/RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift
@@ -13,6 +13,7 @@ enum ProfileNavigationItem: Hashable {
     case restTimeInput
     case standHourPermission
     case goalSettingInput
+    case profileEnd
 }
 
 final class ProfileNavigationRouter: ObservableObject {

--- a/RemoteWellnessSupportApp/Profile/Views/Children/GoalSettingInputView.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/Children/GoalSettingInputView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct GoalSettingInputView: View {
     @Binding var hydrationGoal: String
     @StateObject var viewModel = GoalSettingInputViewModel()
-    @AppStorage(Const.AppStatus.hasCompletedProfileRegister) var hasCompletedProfileRegister = Const.AppDefaults.hasCompletedProfileRegister
+    @EnvironmentObject var router: ProfileNavigationRouter
 
     var saveProfile: () -> Bool
 
@@ -32,7 +32,7 @@ struct GoalSettingInputView: View {
             },
             buttonAction: {
                 if viewModel.inputValidate(goalValue: hydrationGoal), saveProfile() {
-                    hasCompletedProfileRegister = true
+                    router.items.append(.profileEnd)
                 }
             }
         )

--- a/RemoteWellnessSupportApp/Profile/Views/Children/ProfileEndView.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/Children/ProfileEndView.swift
@@ -1,0 +1,33 @@
+//
+//  ProfileEndView.swift
+//  RemoteWellnessSupportApp
+//
+//  Created by 岩本雄貴 on 2024/08/18.
+//
+
+import SwiftUI
+
+struct ProfileEndView: View {
+    @AppStorage(Const.AppStatus.hasCompletedProfileRegister) var hasCompletedProfileRegister = Const.AppDefaults.hasCompletedProfileRegister
+
+    var body: some View {
+        VStack {
+            Text("初期設定完了しました")
+                .font(.title)
+            Spacer()
+            VStack(spacing: 20) {
+                Text("初期登録が一通り完了しました。")
+                Text("次の画面から利用してみましょう。")
+            }
+            Spacer()
+            CommonButtonView(title: "次へ進む") {
+                hasCompletedProfileRegister = true
+            }
+        }
+        .padding(30)
+    }
+}
+
+#Preview {
+    ProfileEndView()
+}

--- a/RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift
+++ b/RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift
@@ -36,6 +36,8 @@ struct ProfileScreen: View {
             GoalSettingInputView(hydrationGoal: $viewModel.hydrationGoal) {
                 viewModel.saveProfile()
             }
+        case .profileEnd:
+            ProfileEndView()
         }
     }
 }

--- a/RemoteWellnessSupportApp/Setting/ViewModels/ReminderSettingViewModel.swift
+++ b/RemoteWellnessSupportApp/Setting/ViewModels/ReminderSettingViewModel.swift
@@ -75,7 +75,7 @@ class ReminderSettingViewModel: BaseViewModel {
                 isNotificationEnabled = true
             }
         } catch {
-            setError(withMessage: "通知の許可リクエストまたは通知スケジュールに失敗しました")
+            setError(withMessage: "通知の許可をリクエスト中にエラーが発生しました。設定を確認してください。")
         }
     }
 
@@ -97,7 +97,7 @@ class ReminderSettingViewModel: BaseViewModel {
             fetchPhysicalConditionReminder()
 
         } catch {
-            setError(withMessage: "体調リマインダーの登録に失敗しました")
+            setError(withMessage: "体調リマインダーの登録に失敗しました。再試行してください。")
         }
     }
 
@@ -107,7 +107,7 @@ class ReminderSettingViewModel: BaseViewModel {
             try hydrationReminderDataSource.insertHydrationReminder(hydrationReminder: hydrationReminder)
             fetchHydrationReminder()
         } catch {
-            setError(withMessage: "水分摂取リマインダーの登録に失敗しました")
+            setError(withMessage: "水分摂取リマインダーの登録に失敗しました。再試行してください。")
         }
     }
 

--- a/RemoteWellnessSupportApp/Setting/ViewModels/ReminderSettingViewModel.swift
+++ b/RemoteWellnessSupportApp/Setting/ViewModels/ReminderSettingViewModel.swift
@@ -68,6 +68,49 @@ class ReminderSettingViewModel: BaseViewModel {
         isNotificationEnabled = false
     }
 
+    func scheduleNotification() async {
+        let center = UNUserNotificationCenter.current()
+        do {
+            if try await center.requestAuthorization(options: [.alert, .sound]) {
+                isNotificationEnabled = true
+            }
+        } catch {
+            setError(withMessage: "通知の許可リクエストまたは通知スケジュールに失敗しました")
+        }
+    }
+
+    func createReminderWithEmptyNotificationSetting() async {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await self.createPhysicalConditionReminder()
+            }
+            group.addTask {
+                await self.createHydrationReminder()
+            }
+        }
+    }
+
+    private func createPhysicalConditionReminder() async {
+        do {
+            let physicalConditionReminder = PhysicalConditionReminder(isActive: false, sendsToiOS: false, sendsTowatchOS: false)
+            try physicalConditionReminderDataSource.insertPhysicalConditionReminder(physicalConditionReminder: physicalConditionReminder)
+            fetchPhysicalConditionReminder()
+
+        } catch {
+            setError(withMessage: "体調リマインダーの登録に失敗しました")
+        }
+    }
+
+    private func createHydrationReminder() async {
+        do {
+            let hydrationReminder = HydrationReminder(isActive: false, sendsToiOS: false, sendsTowatchOS: false)
+            try hydrationReminderDataSource.insertHydrationReminder(hydrationReminder: hydrationReminder)
+            fetchHydrationReminder()
+        } catch {
+            setError(withMessage: "水分摂取リマインダーの登録に失敗しました")
+        }
+    }
+
     private func checkAuthorizeNotificationSetting(center: UNUserNotificationCenter) async -> Bool {
         let checkStatus = await center.notificationSettings()
         if checkStatus.authorizationStatus == .authorized {

--- a/RemoteWellnessSupportApp/Setting/Views/Common/ReminderSection.swift
+++ b/RemoteWellnessSupportApp/Setting/Views/Common/ReminderSection.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ReminderSection: View {
+    @Binding var isNotificationEnabled: Bool
     let title: String
     let reminder: BaseReminderProtocol?
     let action: () -> Void
@@ -18,7 +19,7 @@ struct ReminderSection: View {
                 .font(.headline)
                 .modifier(ReminderSettingView.MaxWidthLeadingAlignmentPaddingModifier())
 
-            if let reminder {
+            if let reminder, isNotificationEnabled {
                 HStack {
                     reminderText(for: reminder)
                     Spacer()
@@ -27,6 +28,10 @@ struct ReminderSection: View {
                     })
                 }
                 .padding(10)
+            } else if !isNotificationEnabled {
+                Text("通知不許可")
+                    .modifier(ReminderSettingView.MaxWidthLeadingAlignmentPaddingModifier())
+
             } else {
                 Text("通知設定なし")
                     .modifier(ReminderSettingView.MaxWidthLeadingAlignmentPaddingModifier())


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated navigation logic to prioritize profile registration completion over notification settings.
- Added new functionality to remove notifications for inactive reminders.
- Created a new view, `ProfileEndView`, to indicate the completion of profile setup.
- Enhanced reminder setting logic to handle default notification setup and status.
- Updated UI components to reflect changes in notification permission and status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>RootView.swift</strong><dd><code>Update navigation logic for onboarding process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Navigation/Views/RootView.swift

<li>Changed the navigation logic to prioritize profile registration <br>completion.<br> <li> Removed notification setting check from the navigation flow.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-1afd3f7968e69df27225b415328a5adcf3859e800c4db6d2bd8c96410dc58fa1">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BaseReminderScheduler.swift</strong><dd><code>Add functionality to remove inactive notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/ViewModels/Commons/BaseReminderScheduler.swift

<li>Added a method to remove notifications for inactive reminders.<br> <li> Checked notification authorization status before removing <br>notifications.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-729494090c864af7620b6a4bdd35143276688738d4a792a8ee0f42c3892649b3">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HydrationReminderEditViewModel.swift</strong><dd><code>Update hydration reminder logic for notification removal</code>&nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/ViewModels/HydrationReminderEditViewModel.swift

<li>Modified logic to remove notifications when hydration reminders are <br>inactive.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-dc52bc2914a65bc1f972bd0a0d254c8bd471328266760d2cd93d8ee355d7a9eb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PhysicalConditionReminderEditViewModel.swift</strong><dd><code>Update physical condition reminder logic for notification removal</code></dd></summary>
<hr>

RemoteWellnessSupportApp/NotificationSetting/ViewModels/PhysicalConditionReminderEditViewModel.swift

<li>Modified logic to remove notifications when physical condition <br>reminders are inactive.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-940a7ffaf95fcbe2d232ec2cfd30cc09cf92ea6534d9af530b320693ecf002c4">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileNavigationRouter.swift</strong><dd><code>Add profile completion navigation item</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/ViewModels/ProfileNavigationRouter.swift

- Added a new navigation item for profile completion.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-0800e64922bb7a5ffa529b55a334ca7194b4b463bfe64dd70851b0d5658037a1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GoalSettingInputView.swift</strong><dd><code>Update goal setting view for profile completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/Children/GoalSettingInputView.swift

<li>Changed completion logic to append a new navigation item upon profile <br>completion.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-467b12513268793238a914d9b1af39d5d47160355431569c797bb2abb97ecc28">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileEndView.swift</strong><dd><code>Add new view for profile setup completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/Children/ProfileEndView.swift

- Created a new view to indicate the completion of profile setup.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-c316fb9ce200132338abf0b9e70dcc3f5c20792f5573ba2463e2dc24e00cd80e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProfileScreen.swift</strong><dd><code>Integrate ProfileEndView into navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Profile/Views/ProfileScreen.swift

<li>Integrated the new ProfileEndView into the profile navigation flow.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-615bb5e39b9e1ce982b98c3d33ce17c819cc96da427f3d3b580c361d1ae9a256">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReminderSettingViewModel.swift</strong><dd><code>Enhance reminder setting with default notification setup</code>&nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Setting/ViewModels/ReminderSettingViewModel.swift

<li>Added methods to schedule notifications and create reminders with <br>default settings.<br> <li> Updated logic to handle notification settings upon first launch.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-9bee491c323251f3b9eba55500bfd8a595a6c6ed42f054f23e3e0477b49b6e24">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReminderSettingView.swift</strong><dd><code>Update reminder setting view for notification status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp/Setting/Views/Children/ReminderSettingView.swift

<li>Updated UI to reflect notification permission status.<br> <li> Modified reminder sections to handle notification enablement.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-89a17e37b0db30348cc4fb5276d597ce3ea0ae31d349f7258330a64d50396299">+11/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReminderSection.swift</strong><dd><code>Enhance reminder section with notification status handling</code></dd></summary>
<hr>

RemoteWellnessSupportApp/Setting/Views/Common/ReminderSection.swift

<li>Added binding for notification enablement status.<br> <li> Displayed message when notifications are not permitted.<br>


</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-07f95adfa313088e2963dfcdc24dd25a6db0b5856b78371372be3dc6e23df74f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Add ProfileEndView to project references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RemoteWellnessSupportApp.xcodeproj/project.pbxproj

- Added ProfileEndView.swift to the project file references.



</details>


  </td>
  <td><a href="https://github.com/y-iwamoto/RemoteWellnessSupportApp/pull/32/files#diff-416f90ec0839507819964497c1a1d436c175cdeb595a1cc542713b25c07ff813">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - プロフィールの設定完了を示す新しい `ProfileEndView` を追加しました。
  - プロフィール管理に関連する新しいナビゲーションオプション `profileEnd` を追加しました。
  - 通知設定を管理する機能を強化する新しいメソッドを追加しました。

- **バグ修正**
  - ユーザーのプロファイル登録状況に基づくナビゲーションフローを簡素化しました。

- **改善**
  - ユーザー通知設定のインタラクションを改善し、UIが現在の通知設定を反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->